### PR TITLE
#345 - Implemented check to prevent inactive users in login

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/controllers/UserLoginHelper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/controllers/UserLoginHelper.java
@@ -25,6 +25,9 @@ public class UserLoginHelper {
     throws GenericException, AuthenticationDeniedException {
     try {
       RodaUser user = UserUtility.getLdapUtility().getAuthenticatedUser(username, password);
+      if (!user.isActive()) {
+        throw new AuthenticationDeniedException("User is not active.");
+      }
       user.setIpAddress(request.getRemoteAddr());
       UserUtility.setUser(request, new RodaSimpleUser(user.getId(), user.getName(), user.getEmail(), user.isGuest()));
       return user;


### PR DESCRIPTION
Issue #345 
Implemented check to prevent inactive users in login.
When an inactive user tries to login a AuthenticationDeniedException is thrown and the user interface shows message "Wrong username or password".

Maybe a different message should be presented. Something like "You must validate your email to login."
To achieve this a new type of exception could be created (InactiveUserAuthenticationDeniedException) and in [this method](https://github.com/keeps/roda/blob/master/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/Login.java#L177) test for that exception and present a different message.

It would also be useful to have a button/link to resend the verification email in the error message.
Something like...

You must validate your email to login. 
* Please check your inbox for the verification email and follow the link in the message, or
* **Click here to resend the verification email**.
