### PR TITLE
#348 Enabled ldap.protectedUsers for *admin* to avoid losing LDAP access

### DIFF
--- a/roda-core/roda-core/src/main/resources/config/roda-core.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-core.properties
@@ -18,8 +18,8 @@ ldap.peopleDN = ou=users,dc=roda,dc=org
 ldap.groupsDN = ou=groups,dc=roda,dc=org
 ldap.rolesDN = ou=roles,dc=roda,dc=org
 # These are the names of the users and groups that cannot be changed
-#ldap.protectedUsers = admin
-#ldap.protectedUsers = guest
+ldap.protectedUsers = admin
+ldap.protectedUsers = guest
 #ldap.protectedGroups = administrators
 #ldap.protectedGroups = archivists
 #ldap.protectedGroups = producers


### PR DESCRIPTION
Issue #348
Enabled ldap.protectedUsers in roda-core.properties to fix error after changing admin password.
