### PR TITLE
Commented checkstyle deprecated checks

### DIFF
--- a/code-style/checkstyle.xml
+++ b/code-style/checkstyle.xml
@@ -44,7 +44,7 @@
 		<module name="NeedBraces" />
 		<module name="RightCurly" />
 		<module name="AvoidInlineConditionals" />
-		<module name="DoubleCheckedLocking" />
+		<!--<module name="DoubleCheckedLocking" />-->
 		<module name="EmptyStatement" />
 		<module name="EqualsHashCode" />
 		<module name="HiddenField">
@@ -55,7 +55,7 @@
 		<module name="InnerAssignment" />
 		<module name="MagicNumber" />
 		<module name="MissingSwitchDefault" />
-		<module name="RedundantThrows" />
+		<!--<module name="RedundantThrows" />-->
 		<module name="SimplifyBooleanExpression" />
 		<module name="SimplifyBooleanReturn" />
 		<module name="FinalClass" />


### PR DESCRIPTION
@luis100 @hsilva-keep checkstyle.xml file is not working with current version of checktyle because it mentions deprecated checks. I commented the old checks.