### PR TITLE
Minor enchancement to statistics plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ For more information, please fell free to visit RODA website:
 
 ### Demo mode (based on docker containers)
 
-#### Windows and MacOS X
+#### Windows
 
 The RODA docker container cannot currently be used in Windows due to filename incompatibilities.
+
+#### MacOS
+
+Just install Kitematic, and search for "roda". Install and run docker container. It's that easy.
 
 #### Linux
 

--- a/roda-ui/roda-wui/src/main/resources/config/theme/js/statistics.js
+++ b/roda-ui/roda-wui/src/main/resources/config/theme/js/statistics.js
@@ -19,32 +19,35 @@
         inheritDataAttributes(element);
 
         var view = element.data("view");
-        var viewCallback = function() {};
+        var initView = function() {};
         if (view == "chart") {
           var viewField = element.data("view-field");
           if (viewField == "facetResults") {
-            viewCallback = initViewFacetChart;
+            initView = initViewFacetChart;
           } else {
             console.log("Unknown view-field '" + viewField + "'");
           }
         } else if (view == "text") {
-          viewCallback = initViewText;
+          initView = initViewText;
         } else if (view == "download") {
-          viewCallback = initViewDownload;
+          initView = initViewDownload;
         } else {
           console.log("Unknown view '" + view + "'");
         }
 
         var source = element.data("source");
+        var dataFunction = function() {};
         if (source == "index") {
-          fetchIndexData(element, viewCallback);
+          dataFunction = fetchIndexData;
         } else if (source == "function") {
           var customFunction = element.data("function");
-          executeFunctionByName(window, customFunction, element,
-            viewCallback);
+          executeFunctionByName(window, customFunction, element);
         } else {
           console.log("Unknown data source '" + source + "'");
         }
+
+        initView(element, dataFunction);
+
       });
     }
 
@@ -57,7 +60,6 @@
       var ref = element.data("ref");
       if (ref) {
         var refElement = document.getElementById(ref);
-        refElement = refElement ? $(refElement) : refElement;
         if (refElement) {
           refElement = $(refElement);
           attributes.forEach(function(attribute) {
@@ -108,14 +110,18 @@
       });
     }
 
-    function initViewText(element, data) {
+    function initViewText(element, dataFunction) {
+      dataFunction(element, viewTextCallback);
+    }
+
+    function viewTextCallback(element, data) {
       element.text(data[element.data("view-field")]);
       element.parent().textfill({
         widthOnly: true
       });
     }
 
-    function initViewDownload(element, data) {
+    function initViewDownload(element, dataFunction) {
       var url = buildDataUrl(element);
       if (element.data("view-field") == "facetResults") {
         url = url + "&exportFacets=true";
@@ -143,7 +149,11 @@
       });
     }
 
-    function initViewFacetChart(element, data) {
+    function initViewFacetChart(element, dataFunction) {
+      dataFunction(element, viewFacetChartCallback);
+    }
+
+    function viewFacetChartCallback(element, data) {
       var chartOptionsCallback;
       var type = element.data("view-type");
       if (type == "function") {


### PR DESCRIPTION
@luis100 @hsilva-keep 

Refactored statistics plugin to call view first, instead of calling data first.

For view "download", calling data first was a waste, because when the button was clicked the data was downloaded again.
Calling view first solves this issue. Only views that need the data immediately will call the data function immediately.