### PR TITLE
Enhanced PluginHelper.createDefaultRisk to read plugin classpath

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/PluginHelper.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/PluginHelper.java
@@ -474,6 +474,11 @@ public final class PluginHelper {
       + RodaConstants.CORE_RISK_FOLDER + '/' + riskId + ".json";
 
     InputStream inputStream = RodaCoreFactory.getDefaultFileAsStream(defaultFile);
+    if (inputStream == null) {
+      inputStream = pluginClass.getResourceAsStream("/" + RodaConstants.CORE_DEFAULT_FOLDER + "/" + defaultFile);
+      LOGGER.trace("Loading default file from plugin classpath {}", defaultFile);
+    }
+
     Risk risk = null;
 
     try {


### PR DESCRIPTION
Enhanced PluginHelper.createDefaultRisk method to try to load resources from plugin classpath if not found in roda-core classpath.