### PR TITLE
Added indexing of descriptive metadata associated with representations

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/IndexModelObserver.java
@@ -265,7 +265,7 @@ public class IndexModelObserver implements ModelObserver {
       }
 
       SolrInputDocument representationDocument = SolrUtils.representationToSolrDocument(aip, representation,
-        sizeInBytes, numberOfDataFiles, numberOfDocumentationFiles, numberOfSchemaFiles, ancestors);
+        sizeInBytes, numberOfDataFiles, numberOfDocumentationFiles, numberOfSchemaFiles, ancestors, model, false);
       index.add(RodaConstants.INDEX_REPRESENTATION, representationDocument);
 
     } catch (SolrServerException | SolrException | IOException | RequestNotValidException | GenericException
@@ -579,6 +579,16 @@ public class IndexModelObserver implements ModelObserver {
         LOGGER.error("Error when descriptive metadata created on retrieving the full AIP", e);
       }
     }
+    else {
+      try {
+        AIP aip = model.retrieveAIP(descriptiveMetadata.getAipId());
+        List<String> ancestors = SolrUtils.getAncestors(aip.getParentId(), model);
+        Representation representation = model.retrieveRepresentation(descriptiveMetadata.getAipId(), descriptiveMetadata.getRepresentationId());
+        indexRepresentation(aip, representation, ancestors);
+      } catch (RequestNotValidException | NotFoundException | GenericException | AuthorizationDeniedException e) {
+        LOGGER.error("Error when descriptive metadata updated on retrieving the full Representation", e);
+      }
+    }
 
     return exceptions;
   }
@@ -594,7 +604,18 @@ public class IndexModelObserver implements ModelObserver {
         LOGGER.error("Error when descriptive metadata updated on retrieving the full AIP", e);
       }
     }
+    else {
+      try {
+        AIP aip = model.retrieveAIP(descriptiveMetadata.getAipId());
+        List<String> ancestors = SolrUtils.getAncestors(aip.getParentId(), model);
+        Representation representation = model.retrieveRepresentation(descriptiveMetadata.getAipId(), descriptiveMetadata.getRepresentationId());
+        indexRepresentation(aip, representation, ancestors);
+      } catch (RequestNotValidException | NotFoundException | GenericException | AuthorizationDeniedException e) {
+        LOGGER.error("Error when descriptive metadata updated on retrieving the full Representation", e);
+      }
+    }
   }
+
 
   @Override
   public void descriptiveMetadataDeleted(String aipId, String representationId, String descriptiveMetadataBinaryId) {

--- a/roda-core/roda-core/src/main/resources/config/index/Representation/conf/schema.xml
+++ b/roda-core/roda-core/src/main/resources/config/index/Representation/conf/schema.xml
@@ -131,7 +131,7 @@
    <copyField source="id" dest="search"/>
    <copyField source="aipId" dest="search"/>
    <copyField source="type" dest="type_txt"/>
-  
+
    <!-- AIP -->
    <field name="state" type="string" indexed="true" stored="true" required="true" multiValued="false" />
    <field name="ingestSIPIds" type="string" indexed="true" stored="true" required="false" multiValued="true" />
@@ -139,6 +139,23 @@
    <field name="ingestUpdateJobIds" type="string" indexed="true" stored="true" required="false" multiValued="true" />
    <dynamicField name="permission_users_*" type="string" indexed="true" stored="true" required="false" multiValued="true" />
    <dynamicField name="permission_groups_*" type="string" indexed="true" stored="true" required="false" multiValued="true" />
+
+    <!-- pataki@: START Copied fropm AIP's schema -->
+    <copyField source="title" dest="title_sort" />
+    <copyField source="*" dest="search" />
+
+    <field name="level" type="string" indexed="true" stored="true" required="false" multiValued="false" />
+    <field name="title" type="text_general" indexed="true" stored="true" required="false" multiValued="false" />
+    <field name="ghost" type="boolean" default="false" indexed="true" stored="true" required="false" multiValued="false" />
+
+    <!-- XXX the field 'title_sort' with the type 'string' was added in order to have correct sorting
+(because 'title' is tokenized and might have other type of transformations that influence sorting)-->
+    <field name="title_sort" type="string" indexed="true" stored="false" required="false" multiValued="false" />
+    <field name="description" type="text_general" indexed="true" stored="true" required="false" multiValued="true" />
+    <field name="dateInitial" type="tdate" indexed="true" stored="true" required="false" multiValued="false" />
+    <field name="dateFinal" type="tdate" indexed="true" stored="true" required="false" multiValued="false" />
+    <!-- pataki@: END -->
+
 
    <!-- Dynamic field definitions allow using convention over configuration
        for fields via the specification of patterns to match field names. 


### PR DESCRIPTION
Following the discussions in #1097 I updated my fork to the current RODA master and applied my patches to make representation metadata indexable and searchable.