### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<name>RODA - Repositório de Objetos Digitais Autênticos</name>
 	<url>http://roda.keep.pt/</url>
 	<groupId>org.roda-project</groupId>
 	<artifactId>roda</artifactId>
-	<version>5.0.0-SNAPSHOT</version>
+	<version>4.0.0</version>
 	<packaging>pom</packaging>
 	<description>RODA is a full-featured open-source digital preservation repository providing all the functionality
 		prescribed by the OAIS reference model.
@@ -71,11 +68,13 @@
 		<grizzly.version>2.4.3</grizzly.version>
 		<solr.version>7.7.3</solr.version>
 		<akka.version>2.5.26</akka.version>
-		<!--<akka_management.version>0.17.0</akka_management.version> -->
+		
+<!--<akka_management.version>0.17.0</akka_management.version> -->
+
 		<apacheds.version>2.0.0-M24</apacheds.version>
 		<httpcomponents.version>4.5.6</httpcomponents.version>
 		<poi.version>3.17</poi.version>
-		<commons_ip2.version>2.0.0-alpha3-SNAPSHOT</commons_ip2.version>
+		<commons_ip2.version>2.0.0-alpha2</commons_ip2.version>
 		<metrics.version>3.2.6</metrics.version>
 		<roda_community_url>http://roda-community.org</roda_community_url>
 		<testng.groups>all</testng.groups>
@@ -293,7 +292,7 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>2.22.2</version>
-				</plugin>
+				<configuration><parallel>all</parallel></configuration></plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-war-plugin</artifactId>
@@ -358,7 +357,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore />
+										<ignore/>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>
@@ -584,34 +583,34 @@
 				<groupId>org.roda-project</groupId>
 				<artifactId>roda-common-data</artifactId>
 				<classifier>sources</classifier>
-				<version>5.0.0-SNAPSHOT</version>
+				<version>4.0.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.roda-project</groupId>
 				<artifactId>roda-common-data</artifactId>
-				<version>5.0.0-SNAPSHOT</version>
+				<version>4.0.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.roda-project</groupId>
 				<artifactId>roda-common-utils</artifactId>
-				<version>5.0.0-SNAPSHOT</version>
+				<version>4.0.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.roda-project</groupId>
 				<artifactId>roda-core</artifactId>
-				<version>5.0.0-SNAPSHOT</version>
+				<version>4.0.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.roda-project</groupId>
 				<artifactId>roda-core-tests</artifactId>
-				<version>5.0.0-SNAPSHOT</version>
+				<version>4.0.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.roda-project</groupId>
 				<artifactId>roda-core-tests</artifactId>
 				<type>test-jar</type>
 				<scope>test</scope>
-				<version>5.0.0-SNAPSHOT</version>
+				<version>4.0.0</version>
 			</dependency>
 			<!-- RODA own modules dependencies - end -->
 			<dependency>


### PR DESCRIPTION

According to [Minimize dynamic and snapshot versions](https://docs.gradle.org/current/userguide/performance.html#minimize_dynamic_and_snapshot_versions), we should avoid using snapshot versions. And a build configuration should always specify exact versions of external libraries to make a build reproduceable. A lack of exact versions can cause problems when new versions of a dependency become available in the future that might introduce incompatible changes.

According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
