### PR TITLE
Convert the plugin that applies the local InstanceID to multi-step

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/local/LocalInstanceIdentifierState.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/synchronization/local/LocalInstanceIdentifierState.java
@@ -5,5 +5,5 @@ package org.roda.core.data.v2.synchronization.local;
  */
 
 public enum LocalInstanceIdentifierState {
-  ACTIVE, INACTIVE;
+  ACTIVE, INACTIVE, RUNNING;
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierAIPPlugin.java
@@ -14,6 +14,7 @@ import org.roda.core.data.exceptions.InvalidParameterException;
 import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.Void;
 import org.roda.core.data.v2.index.filter.Filter;
 import org.roda.core.data.v2.ip.AIP;
 import org.roda.core.data.v2.ip.IndexedAIP;
@@ -28,7 +29,7 @@ import org.roda.core.model.ModelService;
 import org.roda.core.plugins.AbstractPlugin;
 import org.roda.core.plugins.Plugin;
 import org.roda.core.plugins.PluginException;
-import org.roda.core.plugins.RODAObjectsProcessingLogic;
+import org.roda.core.plugins.RODAProcessingLogic;
 import org.roda.core.plugins.orchestrate.JobPluginInfo;
 import org.roda.core.plugins.plugins.PluginHelper;
 import org.roda.core.storage.StorageService;
@@ -40,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * @author Tiago Fraga <tfraga@keep.pt>
  */
 
-public class InstanceIdentifierAIPPlugin extends AbstractPlugin<AIP> {
+public class InstanceIdentifierAIPPlugin extends AbstractPlugin<Void> {
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierAIPPlugin.class);
   private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
 
@@ -133,13 +134,13 @@ public class InstanceIdentifierAIPPlugin extends AbstractPlugin<AIP> {
   }
 
   @Override
-  public Plugin<AIP> cloneMe() {
+  public Plugin<Void> cloneMe() {
     return new InstanceIdentifierAIPPlugin();
   }
 
   @Override
-  public List<Class<AIP>> getObjectClasses() {
-    return Arrays.asList(AIP.class);
+  public List<Class<Void>> getObjectClasses() {
+    return Arrays.asList(Void.class);
   }
 
   @Override
@@ -151,40 +152,38 @@ public class InstanceIdentifierAIPPlugin extends AbstractPlugin<AIP> {
   @Override
   public Report execute(IndexService index, ModelService model, StorageService storage,
     List<LiteOptionalWithCause> list) throws PluginException {
-    return PluginHelper.processObjects(this, new RODAObjectsProcessingLogic<AIP>() {
+    return PluginHelper.processVoids(this, new RODAProcessingLogic<Void>() {
       @Override
       public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
-        JobPluginInfo jobPluginInfo, Plugin<AIP> plugin, List<AIP> lites) {
+        JobPluginInfo jobPluginInfo, Plugin<Void> plugin) throws PluginException {
         try {
           modifyInstanceId(model, index, cachedJob, report, jobPluginInfo);
         } catch (RequestNotValidException | GenericException | NotFoundException e) {
           LOGGER.error("Could not modify Instance ID's in objects");
         }
       }
-    }, index, model, storage, list);
+    }, index, model, storage);
   }
 
   private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
     JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
-    PluginState state = PluginState.SUCCESS;
     String details = "";
 
     // Get AIP's from index
     IterableIndexResult<IndexedAIP> indexedAIPS = retrieveList(index);
-
     for (IndexedAIP indexedAIP : indexedAIPS) {
       Report reportItem = PluginHelper.initPluginReportItem(this, indexedAIP.getId(), AIP.class);
       try {
         model.updateAIPInstanceId(model.retrieveAIP(indexedAIP.getId()));
+        jobPluginInfo.incrementObjectsProcessedWithSuccess();
       } catch (GenericException | NotFoundException | RequestNotValidException | AuthorizationDeniedException e) {
         details = e.getMessage() + "\n";
-        state = PluginState.FAILURE;
+        jobPluginInfo.incrementObjectsProcessedWithFailure();
+        reportItem.setPluginState(PluginState.FAILURE);
+        reportItem.addPluginDetails(details);
+        pluginReport.addReport(reportItem);
+        PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
       }
-      jobPluginInfo.incrementObjectsProcessed(state);
-      reportItem.setPluginState(state);
-      reportItem.addPluginDetails(details);
-      pluginReport.addReport(reportItem);
-      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
   }
 
@@ -195,12 +194,8 @@ public class InstanceIdentifierAIPPlugin extends AbstractPlugin<AIP> {
 
   private IterableIndexResult<IndexedAIP> retrieveList(IndexService index)
     throws RequestNotValidException, GenericException {
-
     Filter filter = new Filter();
 
-    IterableIndexResult<IndexedAIP> indexedAIPS = index.findAll(IndexedAIP.class, filter,
-      Collections.singletonList(RodaConstants.INDEX_UUID));
-
-    return indexedAIPS;
+    return index.findAll(IndexedAIP.class, filter, Collections.singletonList(RodaConstants.INDEX_UUID));
   }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierAIPPlugin.java
@@ -16,7 +16,9 @@ import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.v2.LiteOptionalWithCause;
 import org.roda.core.data.v2.Void;
 import org.roda.core.data.v2.index.filter.Filter;
+import org.roda.core.data.v2.index.filter.SimpleFilterParameter;
 import org.roda.core.data.v2.ip.AIP;
+import org.roda.core.data.v2.ip.AIPState;
 import org.roda.core.data.v2.ip.IndexedAIP;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.PluginParameter;
@@ -176,14 +178,15 @@ public class InstanceIdentifierAIPPlugin extends AbstractPlugin<Void> {
       try {
         model.updateAIPInstanceId(model.retrieveAIP(indexedAIP.getId()));
         jobPluginInfo.incrementObjectsProcessedWithSuccess();
+        reportItem.setPluginState(PluginState.SUCCESS);
       } catch (GenericException | NotFoundException | RequestNotValidException | AuthorizationDeniedException e) {
         details = e.getMessage() + "\n";
         jobPluginInfo.incrementObjectsProcessedWithFailure();
         reportItem.setPluginState(PluginState.FAILURE);
         reportItem.addPluginDetails(details);
-        pluginReport.addReport(reportItem);
-        PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
       }
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
   }
 
@@ -195,7 +198,6 @@ public class InstanceIdentifierAIPPlugin extends AbstractPlugin<Void> {
   private IterableIndexResult<IndexedAIP> retrieveList(IndexService index)
     throws RequestNotValidException, GenericException {
     Filter filter = new Filter();
-
     return index.findAll(IndexedAIP.class, filter, Collections.singletonList(RodaConstants.INDEX_UUID));
   }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierAIPPlugin.java
@@ -1,21 +1,57 @@
 package org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.exceptions.AuthorizationDeniedException;
+import org.roda.core.data.exceptions.GenericException;
+import org.roda.core.data.exceptions.InvalidParameterException;
+import org.roda.core.data.exceptions.NotFoundException;
+import org.roda.core.data.exceptions.RequestNotValidException;
+import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.index.filter.Filter;
 import org.roda.core.data.v2.ip.AIP;
+import org.roda.core.data.v2.ip.IndexedAIP;
+import org.roda.core.data.v2.jobs.Job;
+import org.roda.core.data.v2.jobs.PluginParameter;
+import org.roda.core.data.v2.jobs.PluginState;
+import org.roda.core.data.v2.jobs.PluginType;
+import org.roda.core.data.v2.jobs.Report;
+import org.roda.core.index.IndexService;
+import org.roda.core.index.utils.IterableIndexResult;
+import org.roda.core.model.ModelService;
+import org.roda.core.plugins.AbstractPlugin;
 import org.roda.core.plugins.Plugin;
+import org.roda.core.plugins.PluginException;
+import org.roda.core.plugins.RODAObjectsProcessingLogic;
+import org.roda.core.plugins.orchestrate.JobPluginInfo;
+import org.roda.core.plugins.plugins.PluginHelper;
+import org.roda.core.storage.StorageService;
+import org.roda.core.storage.utils.RODAInstanceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Tiago Fraga <tfraga@keep.pt>
  */
 
-public class InstanceIdentifierAIPPlugin extends InstanceIdentifierRodaEntityPlugin<AIP> {
-  @Override
-  public String getName() {
-    return "AIP instance identifier";
+public class InstanceIdentifierAIPPlugin extends AbstractPlugin<AIP> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierAIPPlugin.class);
+  private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
+
+  static {
+    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER,
+      new PluginParameter(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, "Instance Identifier",
+        PluginParameter.PluginParameterType.STRING, RODAInstanceUtils.retrieveLocalInstanceIdentifierToPlugin(), true,
+        true, "Identifier from the RODA local instance"));
   }
+
+  private String instanceId;
 
   @Override
   public String getVersionImpl() {
@@ -23,13 +59,37 @@ public class InstanceIdentifierAIPPlugin extends InstanceIdentifierRodaEntityPlu
   }
 
   @Override
-  public Plugin<AIP> cloneMe() {
-    return new InstanceIdentifierAIPPlugin();
+  public String getName() {
+    return "AIP instance identifier";
   }
 
   @Override
-  public List<Class<AIP>> getObjectClasses() {
-    return Arrays.asList(AIP.class);
+  public String getDescription() {
+    return "Add the instance identifier on the data that exists on the storage as also on the index. "
+      + "If an object already has an instance identifier it will be updated by the new one. "
+      + "This task aims to help the synchronization between a RODA central instance and the RODA local instance, "
+      + "since when an local object is accessed in RODA Central it should have the instance identifier in order to "
+      + "inform from which source is it from.";
+  }
+
+  @Override
+  public List<PluginParameter> getParameters() {
+    ArrayList<PluginParameter> parameters = new ArrayList<>();
+    parameters.add(pluginParameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER));
+    return parameters;
+  }
+
+  @Override
+  public void setParameterValues(Map<String, String> parameters) throws InvalidParameterException {
+    super.setParameterValues(parameters);
+    if (parameters != null && parameters.containsKey(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER)) {
+      instanceId = parameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER);
+    }
+  }
+
+  @Override
+  public RodaConstants.PreservationEventType getPreservationEventType() {
+    return RodaConstants.PreservationEventType.UPDATE;
   }
 
   @Override
@@ -48,7 +108,99 @@ public class InstanceIdentifierAIPPlugin extends InstanceIdentifierRodaEntityPlu
   }
 
   @Override
-  public RodaConstants.PreservationEventType getPreservationEventType() {
-    return RodaConstants.PreservationEventType.UPDATE;
+  public PluginType getType() {
+    return PluginType.INTERNAL;
+  }
+
+  @Override
+  public List<String> getCategories() {
+    return Arrays.asList(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE);
+  }
+
+  @Override
+  public boolean areParameterValuesValid() {
+    return false;
+  }
+
+  @Override
+  public void init() throws PluginException {
+    // do nothing
+  }
+
+  @Override
+  public void shutdown() {
+    // do nothing
+  }
+
+  @Override
+  public Plugin<AIP> cloneMe() {
+    return new InstanceIdentifierAIPPlugin();
+  }
+
+  @Override
+  public List<Class<AIP>> getObjectClasses() {
+    return Arrays.asList(AIP.class);
+  }
+
+  @Override
+  public Report beforeAllExecute(IndexService index, ModelService model, StorageService storage)
+    throws PluginException {
+    return new Report();
+  }
+
+  @Override
+  public Report execute(IndexService index, ModelService model, StorageService storage,
+    List<LiteOptionalWithCause> list) throws PluginException {
+    return PluginHelper.processObjects(this, new RODAObjectsProcessingLogic<AIP>() {
+      @Override
+      public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
+        JobPluginInfo jobPluginInfo, Plugin<AIP> plugin, List<AIP> lites) {
+        try {
+          modifyInstanceId(model, index, cachedJob, report, jobPluginInfo);
+        } catch (RequestNotValidException | GenericException | NotFoundException e) {
+          LOGGER.error("Could not modify Instance ID's in objects");
+        }
+      }
+    }, index, model, storage, list);
+  }
+
+  private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
+    JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
+    PluginState state = PluginState.SUCCESS;
+    String details = "";
+
+    // Get AIP's from index
+    IterableIndexResult<IndexedAIP> indexedAIPS = retrieveList(index);
+
+    for (IndexedAIP indexedAIP : indexedAIPS) {
+      Report reportItem = PluginHelper.initPluginReportItem(this, indexedAIP.getId(), AIP.class);
+      try {
+        model.updateAIPInstanceId(model.retrieveAIP(indexedAIP.getId()));
+      } catch (GenericException | NotFoundException | RequestNotValidException | AuthorizationDeniedException e) {
+        details = e.getMessage() + "\n";
+        state = PluginState.FAILURE;
+      }
+      jobPluginInfo.incrementObjectsProcessed(state);
+      reportItem.setPluginState(state);
+      reportItem.addPluginDetails(details);
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
+    }
+  }
+
+  @Override
+  public Report afterAllExecute(IndexService index, ModelService model, StorageService storage) throws PluginException {
+    return new Report();
+  }
+
+  private IterableIndexResult<IndexedAIP> retrieveList(IndexService index)
+    throws RequestNotValidException, GenericException {
+
+    Filter filter = new Filter();
+
+    IterableIndexResult<IndexedAIP> indexedAIPS = index.findAll(IndexedAIP.class, filter,
+      Collections.singletonList(RodaConstants.INDEX_UUID));
+
+    return indexedAIPS;
   }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierDIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierDIPPlugin.java
@@ -178,14 +178,15 @@ public class InstanceIdentifierDIPPlugin extends AbstractPlugin<Void> {
       try {
         model.updateDIPInstanceId(model.retrieveDIP(indexedDIP.getId()));
         jobPluginInfo.incrementObjectsProcessedWithSuccess();
+        reportItem.setPluginState(PluginState.SUCCESS);
       } catch (GenericException | NotFoundException | RequestNotValidException | AuthorizationDeniedException e) {
         details = e.getMessage() + "\n";
         jobPluginInfo.incrementObjectsProcessedWithFailure();
         reportItem.setPluginState(PluginState.FAILURE);
         reportItem.addPluginDetails(details);
-        pluginReport.addReport(reportItem);
-        PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
       }
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
   }
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierDIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierDIPPlugin.java
@@ -1,21 +1,58 @@
 package org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.exceptions.AuthorizationDeniedException;
+import org.roda.core.data.exceptions.GenericException;
+import org.roda.core.data.exceptions.InvalidParameterException;
+import org.roda.core.data.exceptions.NotFoundException;
+import org.roda.core.data.exceptions.RequestNotValidException;
+import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.index.filter.Filter;
 import org.roda.core.data.v2.ip.DIP;
+import org.roda.core.data.v2.ip.IndexedDIP;
+import org.roda.core.data.v2.jobs.Job;
+import org.roda.core.data.v2.jobs.PluginParameter;
+import org.roda.core.data.v2.jobs.PluginState;
+import org.roda.core.data.v2.jobs.PluginType;
+import org.roda.core.data.v2.jobs.Report;
+import org.roda.core.index.IndexService;
+import org.roda.core.index.utils.IterableIndexResult;
+import org.roda.core.model.ModelService;
+import org.roda.core.plugins.AbstractPlugin;
 import org.roda.core.plugins.Plugin;
+import org.roda.core.plugins.PluginException;
+import org.roda.core.plugins.RODAObjectsProcessingLogic;
+import org.roda.core.plugins.orchestrate.JobPluginInfo;
+import org.roda.core.plugins.plugins.PluginHelper;
+import org.roda.core.storage.StorageService;
+import org.roda.core.storage.utils.RODAInstanceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Tiago Fraga <tfraga@keep.pt>
  */
 
-public class InstanceIdentifierDIPPlugin extends InstanceIdentifierRodaEntityPlugin<DIP> {
-  @Override
-  public String getName() {
-    return "DIP instance identifier";
+public class InstanceIdentifierDIPPlugin extends AbstractPlugin<DIP> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierDIPPlugin.class);
+  private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
+
+  static {
+    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER,
+      new PluginParameter(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, "Instance Identifier",
+        PluginParameter.PluginParameterType.STRING, RODAInstanceUtils.retrieveLocalInstanceIdentifierToPlugin(), true,
+        true, "Identifier from the RODA local instance"));
   }
+
+  private String instanceId;
 
   @Override
   public String getVersionImpl() {
@@ -23,13 +60,37 @@ public class InstanceIdentifierDIPPlugin extends InstanceIdentifierRodaEntityPlu
   }
 
   @Override
-  public Plugin<DIP> cloneMe() {
-    return new InstanceIdentifierDIPPlugin();
+  public String getName() {
+    return "DIP instance identifier";
   }
 
   @Override
-  public List<Class<DIP>> getObjectClasses() {
-    return Arrays.asList(DIP.class);
+  public String getDescription() {
+    return "Add the instance identifier on the data that exists on the storage as also on the index. "
+      + "If an object already has an instance identifier it will be updated by the new one. "
+      + "This task aims to help the synchronization between a RODA central instance and the RODA local instance, "
+      + "since when an local object is accessed in RODA Central it should have the instance identifier in order to "
+      + "inform from which source is it from.";
+  }
+
+  @Override
+  public List<PluginParameter> getParameters() {
+    ArrayList<PluginParameter> parameters = new ArrayList<>();
+    parameters.add(pluginParameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER));
+    return parameters;
+  }
+
+  @Override
+  public void setParameterValues(Map<String, String> parameters) throws InvalidParameterException {
+    super.setParameterValues(parameters);
+    if (parameters != null && parameters.containsKey(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER)) {
+      instanceId = parameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER);
+    }
+  }
+
+  @Override
+  public RodaConstants.PreservationEventType getPreservationEventType() {
+    return RodaConstants.PreservationEventType.UPDATE;
   }
 
   @Override
@@ -48,7 +109,98 @@ public class InstanceIdentifierDIPPlugin extends InstanceIdentifierRodaEntityPlu
   }
 
   @Override
-  public RodaConstants.PreservationEventType getPreservationEventType() {
-    return RodaConstants.PreservationEventType.UPDATE;
+  public PluginType getType() {
+    return PluginType.INTERNAL;
+  }
+
+  @Override
+  public List<String> getCategories() {
+    return Arrays.asList(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE);
+  }
+
+  @Override
+  public boolean areParameterValuesValid() {
+    return false;
+  }
+
+  @Override
+  public void init() throws PluginException {
+    // do nothing
+  }
+
+  @Override
+  public void shutdown() {
+    // do nothing
+  }
+
+  @Override
+  public Plugin<DIP> cloneMe() {
+    return new InstanceIdentifierDIPPlugin();
+  }
+
+  @Override
+  public List<Class<DIP>> getObjectClasses() {
+    return Arrays.asList(DIP.class);
+  }
+
+  @Override
+  public Report beforeAllExecute(IndexService index, ModelService model, StorageService storage)
+    throws PluginException {
+    return new Report();
+  }
+
+  @Override
+  public Report execute(IndexService index, ModelService model, StorageService storage,
+    List<LiteOptionalWithCause> list) throws PluginException {
+    return PluginHelper.processObjects(this, new RODAObjectsProcessingLogic<DIP>() {
+      @Override
+      public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
+        JobPluginInfo jobPluginInfo, Plugin<DIP> plugin, List<DIP> lites) {
+        try {
+          modifyInstanceId(model, index, cachedJob, report, jobPluginInfo);
+        } catch (RequestNotValidException | GenericException | NotFoundException e) {
+          LOGGER.error("Could not modify Instance ID's in objects");
+        }
+      }
+    }, index, model, storage, list);
+  }
+
+  private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
+    JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
+    PluginState state = PluginState.SUCCESS;
+    String details = "";
+
+    // Get DIP's from index
+    IterableIndexResult<IndexedDIP> indexedDIPS = retrieveList(index);
+
+    for (IndexedDIP indexedDIP : indexedDIPS) {
+      Report reportItem = PluginHelper.initPluginReportItem(this, indexedDIP.getId(), DIP.class);
+      try {
+        model.updateDIPInstanceId(model.retrieveDIP(indexedDIP.getId()));
+      } catch (GenericException | NotFoundException | RequestNotValidException | AuthorizationDeniedException e) {
+        details = e.getMessage() + "\n";
+        state = PluginState.FAILURE;
+      }
+      jobPluginInfo.incrementObjectsProcessed(state);
+      reportItem.setPluginState(state);
+      reportItem.addPluginDetails(details);
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
+    }
+  }
+
+  @Override
+  public Report afterAllExecute(IndexService index, ModelService model, StorageService storage) throws PluginException {
+    return new Report();
+  }
+
+  private IterableIndexResult<IndexedDIP> retrieveList(IndexService index)
+    throws RequestNotValidException, GenericException {
+    Filter filter = new Filter();
+
+    IterableIndexResult<IndexedDIP> indexedDIPS = index.findAll(IndexedDIP.class, filter,
+      Collections.singletonList(RodaConstants.INDEX_UUID));
+
+    return indexedDIPS;
   }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierJobPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierJobPlugin.java
@@ -1,24 +1,134 @@
 package org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.exceptions.AuthorizationDeniedException;
+import org.roda.core.data.exceptions.GenericException;
+import org.roda.core.data.exceptions.InvalidParameterException;
+import org.roda.core.data.exceptions.NotFoundException;
+import org.roda.core.data.exceptions.RequestNotValidException;
+import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.index.filter.Filter;
 import org.roda.core.data.v2.jobs.Job;
+import org.roda.core.data.v2.jobs.PluginParameter;
+import org.roda.core.data.v2.jobs.PluginState;
+import org.roda.core.data.v2.jobs.PluginType;
+import org.roda.core.data.v2.jobs.Report;
+import org.roda.core.index.IndexService;
+import org.roda.core.index.utils.IterableIndexResult;
+import org.roda.core.model.ModelService;
+import org.roda.core.plugins.AbstractPlugin;
 import org.roda.core.plugins.Plugin;
+import org.roda.core.plugins.PluginException;
+import org.roda.core.plugins.RODAObjectsProcessingLogic;
+import org.roda.core.plugins.orchestrate.JobPluginInfo;
+import org.roda.core.plugins.plugins.PluginHelper;
+import org.roda.core.storage.StorageService;
+import org.roda.core.storage.utils.RODAInstanceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Tiago Fraga <tfraga@keep.pt>
  */
 
-public class InstanceIdentifierJobPlugin extends InstanceIdentifierRodaEntityPlugin<Job> {
+public class InstanceIdentifierJobPlugin extends AbstractPlugin<Job> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierJobPlugin.class);
+  private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
+
+  static {
+    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER,
+      new PluginParameter(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, "Instance Identifier",
+        PluginParameter.PluginParameterType.STRING, RODAInstanceUtils.retrieveLocalInstanceIdentifierToPlugin(), true,
+        true, "Identifier from the RODA local instance"));
+  }
+
+  private String instanceId;
+
+  @Override
+  public String getVersionImpl() {
+    return "1.0";
+  }
+
   @Override
   public String getName() {
     return "Job instance identifier";
   }
 
   @Override
-  public String getVersionImpl() {
-    return "1.0";
+  public String getDescription() {
+    return "Add the instance identifier on the data that exists on the storage as also on the index. "
+      + "If an object already has an instance identifier it will be updated by the new one. "
+      + "This task aims to help the synchronization between a RODA central instance and the RODA local instance, "
+      + "since when an local object is accessed in RODA Central it should have the instance identifier in order to "
+      + "inform from which source is it from.";
+  }
+
+  @Override
+  public List<PluginParameter> getParameters() {
+    ArrayList<PluginParameter> parameters = new ArrayList<>();
+    parameters.add(pluginParameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER));
+    return parameters;
+  }
+
+  @Override
+  public void setParameterValues(Map<String, String> parameters) throws InvalidParameterException {
+    super.setParameterValues(parameters);
+    if (parameters != null && parameters.containsKey(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER)) {
+      instanceId = parameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER);
+    }
+  }
+
+  @Override
+  public RodaConstants.PreservationEventType getPreservationEventType() {
+    return RodaConstants.PreservationEventType.UPDATE;
+  }
+
+  @Override
+  public String getPreservationEventDescription() {
+    return "Updated the instance identifier";
+  }
+
+  @Override
+  public String getPreservationEventSuccessMessage() {
+    return "The instance identifier was updated successfully";
+  }
+
+  @Override
+  public String getPreservationEventFailureMessage() {
+    return "Could not update the instance identifier";
+  }
+
+  @Override
+  public PluginType getType() {
+    return PluginType.INTERNAL;
+  }
+
+  @Override
+  public List<String> getCategories() {
+    return Arrays.asList(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE);
+  }
+
+  @Override
+  public boolean areParameterValuesValid() {
+    return false;
+  }
+
+  @Override
+  public void init() throws PluginException {
+    // do nothing
+  }
+
+  @Override
+  public void shutdown() {
+    // do nothing
   }
 
   @Override
@@ -29,5 +139,65 @@ public class InstanceIdentifierJobPlugin extends InstanceIdentifierRodaEntityPlu
   @Override
   public List<Class<Job>> getObjectClasses() {
     return Arrays.asList(Job.class);
+  }
+
+  @Override
+  public Report beforeAllExecute(IndexService index, ModelService model, StorageService storage)
+    throws PluginException {
+    return new Report();
+  }
+
+  @Override
+  public Report execute(IndexService index, ModelService model, StorageService storage,
+    List<LiteOptionalWithCause> list) throws PluginException {
+    return PluginHelper.processObjects(this, new RODAObjectsProcessingLogic<Job>() {
+      @Override
+      public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
+        JobPluginInfo jobPluginInfo, Plugin<Job> plugin, List<Job> lites) {
+        try {
+          modifyInstanceId(model, index, cachedJob, report, jobPluginInfo);
+        } catch (RequestNotValidException | GenericException | NotFoundException e) {
+          LOGGER.error("Could not modify Instance ID's in objects");
+        }
+      }
+    }, index, model, storage, list);
+  }
+
+  private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
+    JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
+    PluginState state = PluginState.SUCCESS;
+    String details = "";
+
+    // Get Jobs from index
+    IterableIndexResult<Job> indexedJobs = retrieveList(index);
+
+    for (Job indexedJob : indexedJobs) {
+      Report reportItem = PluginHelper.initPluginReportItem(this, indexedJob.getId(), Job.class);
+      try {
+        model.updateJobInstanceId(model.retrieveJob(indexedJob.getId()));
+      } catch (GenericException | NotFoundException | RequestNotValidException | AuthorizationDeniedException e) {
+        details = e.getMessage() + "\n";
+        state = PluginState.FAILURE;
+      }
+      jobPluginInfo.incrementObjectsProcessed(state);
+      reportItem.setPluginState(state);
+      reportItem.addPluginDetails(details);
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
+    }
+  }
+
+  @Override
+  public Report afterAllExecute(IndexService index, ModelService model, StorageService storage) throws PluginException {
+    return new Report();
+  }
+
+  private IterableIndexResult<Job> retrieveList(IndexService index) throws RequestNotValidException, GenericException {
+    Filter filter = new Filter();
+
+    IterableIndexResult<Job> indexedJobs = index.findAll(Job.class, filter,
+      Collections.singletonList(RodaConstants.INDEX_UUID));
+
+    return indexedJobs;
   }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierJobPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierJobPlugin.java
@@ -176,14 +176,15 @@ public class InstanceIdentifierJobPlugin extends AbstractPlugin<Void> {
       try {
         model.updateJobInstanceId(model.retrieveJob(indexedJob.getId()));
         jobPluginInfo.incrementObjectsProcessedWithSuccess();
+        reportItem.setPluginState(PluginState.SUCCESS);
       } catch (GenericException | NotFoundException | RequestNotValidException | AuthorizationDeniedException e) {
         details = e.getMessage() + "\n";
         jobPluginInfo.incrementObjectsProcessedWithFailure();
         reportItem.setPluginState(PluginState.FAILURE);
         reportItem.addPluginDetails(details);
-        pluginReport.addReport(reportItem);
-        PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
       }
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
   }
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierJobPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierJobPlugin.java
@@ -14,6 +14,7 @@ import org.roda.core.data.exceptions.InvalidParameterException;
 import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.Void;
 import org.roda.core.data.v2.index.filter.Filter;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.PluginParameter;
@@ -26,7 +27,7 @@ import org.roda.core.model.ModelService;
 import org.roda.core.plugins.AbstractPlugin;
 import org.roda.core.plugins.Plugin;
 import org.roda.core.plugins.PluginException;
-import org.roda.core.plugins.RODAObjectsProcessingLogic;
+import org.roda.core.plugins.RODAProcessingLogic;
 import org.roda.core.plugins.orchestrate.JobPluginInfo;
 import org.roda.core.plugins.plugins.PluginHelper;
 import org.roda.core.storage.StorageService;
@@ -38,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * @author Tiago Fraga <tfraga@keep.pt>
  */
 
-public class InstanceIdentifierJobPlugin extends AbstractPlugin<Job> {
+public class InstanceIdentifierJobPlugin extends AbstractPlugin<Void> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierJobPlugin.class);
   private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
@@ -132,13 +133,13 @@ public class InstanceIdentifierJobPlugin extends AbstractPlugin<Job> {
   }
 
   @Override
-  public Plugin<Job> cloneMe() {
+  public Plugin<Void> cloneMe() {
     return new InstanceIdentifierJobPlugin();
   }
 
   @Override
-  public List<Class<Job>> getObjectClasses() {
-    return Arrays.asList(Job.class);
+  public List<Class<Void>> getObjectClasses() {
+    return Arrays.asList(Void.class);
   }
 
   @Override
@@ -150,22 +151,21 @@ public class InstanceIdentifierJobPlugin extends AbstractPlugin<Job> {
   @Override
   public Report execute(IndexService index, ModelService model, StorageService storage,
     List<LiteOptionalWithCause> list) throws PluginException {
-    return PluginHelper.processObjects(this, new RODAObjectsProcessingLogic<Job>() {
+    return PluginHelper.processVoids(this, new RODAProcessingLogic<Void>() {
       @Override
       public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
-        JobPluginInfo jobPluginInfo, Plugin<Job> plugin, List<Job> lites) {
+        JobPluginInfo jobPluginInfo, Plugin<Void> plugin) throws PluginException {
         try {
           modifyInstanceId(model, index, cachedJob, report, jobPluginInfo);
         } catch (RequestNotValidException | GenericException | NotFoundException e) {
           LOGGER.error("Could not modify Instance ID's in objects");
         }
       }
-    }, index, model, storage, list);
+    }, index, model, storage);
   }
 
   private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
     JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
-    PluginState state = PluginState.SUCCESS;
     String details = "";
 
     // Get Jobs from index
@@ -175,15 +175,15 @@ public class InstanceIdentifierJobPlugin extends AbstractPlugin<Job> {
       Report reportItem = PluginHelper.initPluginReportItem(this, indexedJob.getId(), Job.class);
       try {
         model.updateJobInstanceId(model.retrieveJob(indexedJob.getId()));
+        jobPluginInfo.incrementObjectsProcessedWithSuccess();
       } catch (GenericException | NotFoundException | RequestNotValidException | AuthorizationDeniedException e) {
         details = e.getMessage() + "\n";
-        state = PluginState.FAILURE;
+        jobPluginInfo.incrementObjectsProcessedWithFailure();
+        reportItem.setPluginState(PluginState.FAILURE);
+        reportItem.addPluginDetails(details);
+        pluginReport.addReport(reportItem);
+        PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
       }
-      jobPluginInfo.incrementObjectsProcessed(state);
-      reportItem.setPluginState(state);
-      reportItem.addPluginDetails(details);
-      pluginReport.addReport(reportItem);
-      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
   }
 
@@ -195,9 +195,6 @@ public class InstanceIdentifierJobPlugin extends AbstractPlugin<Job> {
   private IterableIndexResult<Job> retrieveList(IndexService index) throws RequestNotValidException, GenericException {
     Filter filter = new Filter();
 
-    IterableIndexResult<Job> indexedJobs = index.findAll(Job.class, filter,
-      Collections.singletonList(RodaConstants.INDEX_UUID));
-
-    return indexedJobs;
+    return index.findAll(Job.class, filter, Collections.singletonList(RodaConstants.INDEX_UUID));
   }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierNotificationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierNotificationPlugin.java
@@ -168,25 +168,37 @@ public class InstanceIdentifierNotificationPlugin extends AbstractPlugin<Void> {
   private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
     JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
     String details = "";
-
+    PluginState pluginState = PluginState.SKIPPED;
+    int countFail = 0;
+    int countSuccess = 0;
     // Get Notifications from index
     IterableIndexResult<Notification> indexedNotifications = retrieveList(index);
+    Report reportItem = PluginHelper.initPluginReportItem(this, cachedJob.getId(), Job.class);
+    PluginHelper.updatePartialJobReport(this, model, reportItem, false, cachedJob);
 
     for (Notification indexedNotification : indexedNotifications) {
-      Report reportItem = PluginHelper.initPluginReportItem(this, indexedNotification.getId(), Notification.class);
       try {
         model.updateNotificationInstanceId(model.retrieveNotification(indexedNotification.getId()));
-        jobPluginInfo.incrementObjectsProcessedWithSuccess();
-        reportItem.setPluginState(PluginState.SUCCESS);
+        pluginState = PluginState.SUCCESS;
+        countSuccess++;
       } catch (GenericException | NotFoundException | AuthorizationDeniedException e) {
         details = e.getMessage() + "\n";
-        jobPluginInfo.incrementObjectsProcessedWithFailure();
-        reportItem.setPluginState(PluginState.FAILURE);
-        reportItem.addPluginDetails(details);
+        pluginState = PluginState.FAILURE;
+        countFail++;
       }
-      pluginReport.addReport(reportItem);
-      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
+
+    if (countFail > 0) {
+      details = "Updated the instance identifier on " + countSuccess + " Notifications and failed to update " + countFail;
+    } else if (countSuccess > 0) {
+      details = "Updated the instance identifier on " + countSuccess + " Notifications";
+    }
+
+    reportItem.setPluginDetails(details);
+    jobPluginInfo.incrementObjectsProcessed(pluginState);
+    reportItem.setPluginState(pluginState);
+    pluginReport.addReport(reportItem);
+    PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierNotificationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierNotificationPlugin.java
@@ -177,14 +177,15 @@ public class InstanceIdentifierNotificationPlugin extends AbstractPlugin<Void> {
       try {
         model.updateNotificationInstanceId(model.retrieveNotification(indexedNotification.getId()));
         jobPluginInfo.incrementObjectsProcessedWithSuccess();
+        reportItem.setPluginState(PluginState.SUCCESS);
       } catch (GenericException | NotFoundException | AuthorizationDeniedException e) {
         details = e.getMessage() + "\n";
         jobPluginInfo.incrementObjectsProcessedWithFailure();
         reportItem.setPluginState(PluginState.FAILURE);
         reportItem.addPluginDetails(details);
-        pluginReport.addReport(reportItem);
-        PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
       }
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
   }
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierNotificationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierNotificationPlugin.java
@@ -1,24 +1,135 @@
 package org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.exceptions.AuthorizationDeniedException;
+import org.roda.core.data.exceptions.GenericException;
+import org.roda.core.data.exceptions.InvalidParameterException;
+import org.roda.core.data.exceptions.NotFoundException;
+import org.roda.core.data.exceptions.RequestNotValidException;
+import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.index.filter.Filter;
+import org.roda.core.data.v2.jobs.Job;
+import org.roda.core.data.v2.jobs.PluginParameter;
+import org.roda.core.data.v2.jobs.PluginState;
+import org.roda.core.data.v2.jobs.PluginType;
+import org.roda.core.data.v2.jobs.Report;
 import org.roda.core.data.v2.notifications.Notification;
+import org.roda.core.index.IndexService;
+import org.roda.core.index.utils.IterableIndexResult;
+import org.roda.core.model.ModelService;
+import org.roda.core.plugins.AbstractPlugin;
 import org.roda.core.plugins.Plugin;
+import org.roda.core.plugins.PluginException;
+import org.roda.core.plugins.RODAObjectsProcessingLogic;
+import org.roda.core.plugins.orchestrate.JobPluginInfo;
+import org.roda.core.plugins.plugins.PluginHelper;
+import org.roda.core.storage.StorageService;
+import org.roda.core.storage.utils.RODAInstanceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Tiago Fraga <tfraga@keep.pt>
  */
 
-public class InstanceIdentifierNotificationPlugin extends InstanceIdentifierRodaEntityPlugin<Notification> {
+public class InstanceIdentifierNotificationPlugin extends AbstractPlugin<Notification> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierNotificationPlugin.class);
+  private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
+
+  static {
+    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER,
+      new PluginParameter(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, "Instance Identifier",
+        PluginParameter.PluginParameterType.STRING, RODAInstanceUtils.retrieveLocalInstanceIdentifierToPlugin(), true,
+        true, "Identifier from the RODA local instance"));
+  }
+
+  private String instanceId;
+
+  @Override
+  public String getVersionImpl() {
+    return "1.0";
+  }
+
   @Override
   public String getName() {
     return "Notification instance identifier";
   }
 
   @Override
-  public String getVersionImpl() {
-    return "1.0";
+  public String getDescription() {
+    return "Add the instance identifier on the data that exists on the storage as also on the index. "
+      + "If an object already has an instance identifier it will be updated by the new one. "
+      + "This task aims to help the synchronization between a RODA central instance and the RODA local instance, "
+      + "since when an local object is accessed in RODA Central it should have the instance identifier in order to "
+      + "inform from which source is it from.";
+  }
+
+  @Override
+  public List<PluginParameter> getParameters() {
+    ArrayList<PluginParameter> parameters = new ArrayList<>();
+    parameters.add(pluginParameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER));
+    return parameters;
+  }
+
+  @Override
+  public void setParameterValues(Map<String, String> parameters) throws InvalidParameterException {
+    super.setParameterValues(parameters);
+    if (parameters != null && parameters.containsKey(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER)) {
+      instanceId = parameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER);
+    }
+  }
+
+  @Override
+  public RodaConstants.PreservationEventType getPreservationEventType() {
+    return RodaConstants.PreservationEventType.UPDATE;
+  }
+
+  @Override
+  public String getPreservationEventDescription() {
+    return "Updated the instance identifier";
+  }
+
+  @Override
+  public String getPreservationEventSuccessMessage() {
+    return "The instance identifier was updated successfully";
+  }
+
+  @Override
+  public String getPreservationEventFailureMessage() {
+    return "Could not update the instance identifier";
+  }
+
+  @Override
+  public PluginType getType() {
+    return PluginType.INTERNAL;
+  }
+
+  @Override
+  public List<String> getCategories() {
+    return Arrays.asList(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE);
+  }
+
+  @Override
+  public boolean areParameterValuesValid() {
+    return false;
+  }
+
+  @Override
+  public void init() throws PluginException {
+    // do nothing
+  }
+
+  @Override
+  public void shutdown() {
+    // do nothing
   }
 
   @Override
@@ -29,5 +140,67 @@ public class InstanceIdentifierNotificationPlugin extends InstanceIdentifierRoda
   @Override
   public List<Class<Notification>> getObjectClasses() {
     return Arrays.asList(Notification.class);
+  }
+
+  @Override
+  public Report beforeAllExecute(IndexService index, ModelService model, StorageService storage)
+    throws PluginException {
+    return new Report();
+  }
+
+  @Override
+  public Report execute(IndexService index, ModelService model, StorageService storage,
+    List<LiteOptionalWithCause> list) throws PluginException {
+    return PluginHelper.processObjects(this, new RODAObjectsProcessingLogic<Notification>() {
+      @Override
+      public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
+        JobPluginInfo jobPluginInfo, Plugin<Notification> plugin, List<Notification> lites) {
+        try {
+          modifyInstanceId(model, index, cachedJob, report, jobPluginInfo);
+        } catch (RequestNotValidException | GenericException | NotFoundException e) {
+          LOGGER.error("Could not modify Instance ID's in objects");
+        }
+      }
+    }, index, model, storage, list);
+  }
+
+  private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
+    JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
+    PluginState state = PluginState.SUCCESS;
+    String details = "";
+
+    // Get Notifications from index
+    IterableIndexResult<Notification> indexedNotifications = retrieveList(index);
+
+    for (Notification indexedNotification : indexedNotifications) {
+      Report reportItem = PluginHelper.initPluginReportItem(this, indexedNotification.getId(), Notification.class);
+      try {
+        model.updateNotificationInstanceId(model.retrieveNotification(indexedNotification.getId()));
+      } catch (GenericException | NotFoundException | AuthorizationDeniedException e) {
+        details = e.getMessage() + "\n";
+        state = PluginState.FAILURE;
+      }
+      jobPluginInfo.incrementObjectsProcessed(state);
+      reportItem.setPluginState(state);
+      reportItem.addPluginDetails(details);
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
+    }
+  }
+
+  @Override
+  public Report afterAllExecute(IndexService index, ModelService model, StorageService storage) throws PluginException {
+    return new Report();
+  }
+
+  private IterableIndexResult<Notification> retrieveList(IndexService index)
+    throws RequestNotValidException, GenericException {
+
+    Filter filter = new Filter();
+
+    IterableIndexResult<Notification> indexedNotifications = index.findAll(Notification.class, filter,
+      Collections.singletonList(RodaConstants.INDEX_UUID));
+
+    return indexedNotifications;
   }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRepositoryEventPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRepositoryEventPlugin.java
@@ -2,6 +2,7 @@ package org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifie
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +17,10 @@ import org.roda.core.data.exceptions.InstanceIdNotUpdated;
 import org.roda.core.data.exceptions.InvalidParameterException;
 import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.Void;
+import org.roda.core.data.v2.index.filter.EmptyKeyFilterParameter;
+import org.roda.core.data.v2.index.filter.Filter;
+import org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent;
 import org.roda.core.data.v2.ip.metadata.PreservationMetadata;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.PluginParameter;
@@ -24,11 +29,12 @@ import org.roda.core.data.v2.jobs.PluginType;
 import org.roda.core.data.v2.jobs.Report;
 import org.roda.core.data.v2.validation.ValidationException;
 import org.roda.core.index.IndexService;
+import org.roda.core.index.utils.IterableIndexResult;
 import org.roda.core.model.ModelService;
 import org.roda.core.plugins.AbstractPlugin;
 import org.roda.core.plugins.Plugin;
 import org.roda.core.plugins.PluginException;
-import org.roda.core.plugins.RODAObjectProcessingLogic;
+import org.roda.core.plugins.RODAProcessingLogic;
 import org.roda.core.plugins.orchestrate.JobPluginInfo;
 import org.roda.core.plugins.plugins.PluginHelper;
 import org.roda.core.storage.StorageService;
@@ -40,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * @author Tiago Fraga <tfraga@keep.pt>
  */
 
-public class InstanceIdentifierRepositoryEventPlugin extends AbstractPlugin<PreservationMetadata> {
+public class InstanceIdentifierRepositoryEventPlugin extends AbstractPlugin<Void> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierRepositoryEventPlugin.class);
   private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
@@ -120,7 +126,7 @@ public class InstanceIdentifierRepositoryEventPlugin extends AbstractPlugin<Pres
   }
 
   @Override
-  public Plugin<PreservationMetadata> cloneMe() {
+  public Plugin<Void> cloneMe() {
     return new InstanceIdentifierRepositoryEventPlugin();
   }
 
@@ -140,8 +146,8 @@ public class InstanceIdentifierRepositoryEventPlugin extends AbstractPlugin<Pres
   }
 
   @Override
-  public List<Class<PreservationMetadata>> getObjectClasses() {
-    return Arrays.asList(PreservationMetadata.class);
+  public List<Class<Void>> getObjectClasses() {
+    return Arrays.asList(Void.class);
   }
 
   @Override
@@ -153,35 +159,52 @@ public class InstanceIdentifierRepositoryEventPlugin extends AbstractPlugin<Pres
   @Override
   public Report execute(IndexService index, ModelService model, StorageService storage,
     List<LiteOptionalWithCause> list) throws PluginException {
-    return PluginHelper.processObjects(this, new RODAObjectProcessingLogic<PreservationMetadata>() {
+    return PluginHelper.processVoids(this, new RODAProcessingLogic<Void>() {
       @Override
       public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
-        JobPluginInfo jobPluginInfo, Plugin<PreservationMetadata> plugin, PreservationMetadata object) {
-        modifyInstanceId(model, index, report, jobPluginInfo, object);
+        JobPluginInfo jobPluginInfo, Plugin<Void> plugin) throws PluginException {
+        try {
+          modifyInstanceId(model, index, cachedJob, report, jobPluginInfo);
+        } catch (RequestNotValidException | GenericException e) {
+          LOGGER.error("Could not modify Instance ID's in objects");
+        }
       }
-    }, index, model, storage, list);
+    }, index, model, storage);
   }
 
-  private void modifyInstanceId(ModelService model, IndexService index, Report pluginReport,
-    JobPluginInfo jobPluginInfo, PreservationMetadata pm) {
-    pluginReport.setPluginState(PluginState.SUCCESS);
+  private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
+    JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException {
 
-    try {
-      PremisV3Utils.updatePremisEventInstanceId(pm, model, index, instanceId);
-      jobPluginInfo.incrementObjectsProcessedWithSuccess();
-    } catch (AuthorizationDeniedException | RequestNotValidException | GenericException | ValidationException
-      | AlreadyExistsException | InstanceIdNotUpdated e) {
-      jobPluginInfo.incrementObjectsProcessedWithFailure();
-      pluginReport.setPluginState(PluginState.FAILURE)
-        .addPluginDetails("Could not update instance id on repository preservation event: " + e.getCause());
-    } catch (AlreadyHasInstanceIdentifier alreadyHasInstanceIdentifier) {
-      jobPluginInfo.incrementObjectsProcessedWithSkipped();
+    IterableIndexResult<IndexedPreservationEvent> indexedPreservationEvents = retrieveList(index);
+    for (IndexedPreservationEvent indexedPreservationEvent : indexedPreservationEvents) {
+      Report reportItem = PluginHelper.initPluginReportItem(this, indexedPreservationEvent.getId(),
+        PreservationMetadata.class);
+      try {
+        PremisV3Utils.updatePremisEventInstanceId(model.retrievePreservationMetadata(indexedPreservationEvent.getId(),
+          PreservationMetadata.PreservationMetadataType.EVENT), model, index, instanceId);
+        jobPluginInfo.incrementObjectsProcessedWithSuccess();
+        reportItem.setPluginState(PluginState.SUCCESS);
+      } catch (AuthorizationDeniedException | RequestNotValidException | GenericException | ValidationException
+        | AlreadyExistsException | InstanceIdNotUpdated e) {
+        jobPluginInfo.incrementObjectsProcessedWithFailure();
+        reportItem.setPluginState(PluginState.FAILURE)
+          .addPluginDetails("Could not update instance id on repository preservation event: " + e.getCause());
+      } catch (AlreadyHasInstanceIdentifier alreadyHasInstanceIdentifier) {
+        jobPluginInfo.incrementObjectsProcessedWithSkipped();
+      }
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
-
   }
 
   @Override
   public Report afterAllExecute(IndexService index, ModelService model, StorageService storage) throws PluginException {
     return new Report();
+  }
+
+  private IterableIndexResult<IndexedPreservationEvent> retrieveList(IndexService index)
+    throws RequestNotValidException, GenericException {
+    Filter filter = new Filter(new EmptyKeyFilterParameter(RodaConstants.PRESERVATION_EVENT_AIP_ID));
+    return index.findAll(IndexedPreservationEvent.class, filter, Collections.singletonList(RodaConstants.INDEX_UUID));
   }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRepresentationInformationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRepresentationInformationPlugin.java
@@ -1,25 +1,135 @@
 package org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.exceptions.AuthorizationDeniedException;
+import org.roda.core.data.exceptions.GenericException;
+import org.roda.core.data.exceptions.InvalidParameterException;
+import org.roda.core.data.exceptions.NotFoundException;
+import org.roda.core.data.exceptions.RequestNotValidException;
+import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.index.filter.Filter;
+import org.roda.core.data.v2.jobs.Job;
+import org.roda.core.data.v2.jobs.PluginParameter;
+import org.roda.core.data.v2.jobs.PluginState;
+import org.roda.core.data.v2.jobs.PluginType;
+import org.roda.core.data.v2.jobs.Report;
 import org.roda.core.data.v2.ri.RepresentationInformation;
+import org.roda.core.index.IndexService;
+import org.roda.core.index.utils.IterableIndexResult;
+import org.roda.core.model.ModelService;
+import org.roda.core.plugins.AbstractPlugin;
 import org.roda.core.plugins.Plugin;
+import org.roda.core.plugins.PluginException;
+import org.roda.core.plugins.RODAObjectsProcessingLogic;
+import org.roda.core.plugins.orchestrate.JobPluginInfo;
+import org.roda.core.plugins.plugins.PluginHelper;
+import org.roda.core.storage.StorageService;
+import org.roda.core.storage.utils.RODAInstanceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Tiago Fraga <tfraga@keep.pt>
  */
 
-public class InstanceIdentifierRepresentationInformationPlugin
-  extends InstanceIdentifierRodaEntityPlugin<RepresentationInformation> {
+public class InstanceIdentifierRepresentationInformationPlugin extends AbstractPlugin<RepresentationInformation> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierRepresentationInformationPlugin.class);
+  private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
+
+  static {
+    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER,
+      new PluginParameter(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, "Instance Identifier",
+        PluginParameter.PluginParameterType.STRING, RODAInstanceUtils.retrieveLocalInstanceIdentifierToPlugin(), true,
+        true, "Identifier from the RODA local instance"));
+  }
+
+  private String instanceId;
+
+  @Override
+  public String getVersionImpl() {
+    return "1.0";
+  }
+
   @Override
   public String getName() {
     return "Representation Information instance identifier";
   }
 
   @Override
-  public String getVersionImpl() {
-    return "1.0";
+  public String getDescription() {
+    return "Add the instance identifier on the data that exists on the storage as also on the index. "
+      + "If an object already has an instance identifier it will be updated by the new one. "
+      + "This task aims to help the synchronization between a RODA central instance and the RODA local instance, "
+      + "since when an local object is accessed in RODA Central it should have the instance identifier in order to "
+      + "inform from which source is it from.";
+  }
+
+  @Override
+  public List<PluginParameter> getParameters() {
+    ArrayList<PluginParameter> parameters = new ArrayList<>();
+    parameters.add(pluginParameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER));
+    return parameters;
+  }
+
+  @Override
+  public void setParameterValues(Map<String, String> parameters) throws InvalidParameterException {
+    super.setParameterValues(parameters);
+    if (parameters != null && parameters.containsKey(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER)) {
+      instanceId = parameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER);
+    }
+  }
+
+  @Override
+  public RodaConstants.PreservationEventType getPreservationEventType() {
+    return RodaConstants.PreservationEventType.UPDATE;
+  }
+
+  @Override
+  public String getPreservationEventDescription() {
+    return "Updated the instance identifier";
+  }
+
+  @Override
+  public String getPreservationEventSuccessMessage() {
+    return "The instance identifier was updated successfully";
+  }
+
+  @Override
+  public String getPreservationEventFailureMessage() {
+    return "Could not update the instance identifier";
+  }
+
+  @Override
+  public PluginType getType() {
+    return PluginType.INTERNAL;
+  }
+
+  @Override
+  public List<String> getCategories() {
+    return Arrays.asList(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE);
+  }
+
+  @Override
+  public boolean areParameterValuesValid() {
+    return false;
+  }
+
+  @Override
+  public void init() throws PluginException {
+    // do nothing
+  }
+
+  @Override
+  public void shutdown() {
+    // do nothing
   }
 
   @Override
@@ -32,4 +142,68 @@ public class InstanceIdentifierRepresentationInformationPlugin
     return Arrays.asList(RepresentationInformation.class);
   }
 
+  @Override
+  public Report beforeAllExecute(IndexService index, ModelService model, StorageService storage)
+    throws PluginException {
+    return new Report();
+  }
+
+  @Override
+  public Report execute(IndexService index, ModelService model, StorageService storage,
+    List<LiteOptionalWithCause> list) throws PluginException {
+    return PluginHelper.processObjects(this, new RODAObjectsProcessingLogic<RepresentationInformation>() {
+      @Override
+      public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
+        JobPluginInfo jobPluginInfo, Plugin<RepresentationInformation> plugin, List<RepresentationInformation> lites) {
+        try {
+          modifyInstanceId(model, index, cachedJob, report, jobPluginInfo);
+        } catch (RequestNotValidException | GenericException | NotFoundException e) {
+          LOGGER.error("Could not modify Instance ID's in objects");
+        }
+      }
+    }, index, model, storage, list);
+  }
+
+  private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
+    JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
+    PluginState state = PluginState.SUCCESS;
+    String details = "";
+
+    // Get AIP's from index
+    IterableIndexResult<RepresentationInformation> indexedRepresentationInformations = retrieveList(index);
+
+    for (RepresentationInformation indexedRepresentationInformation : indexedRepresentationInformations) {
+      Report reportItem = PluginHelper.initPluginReportItem(this, indexedRepresentationInformation.getId(),
+        RepresentationInformation.class);
+      try {
+        model.updateRepresentationInformationInstanceId(
+          model.retrieveRepresentationInformation(indexedRepresentationInformation.getId()), cachedJob.getUsername(),
+          true);
+      } catch (GenericException | NotFoundException | RequestNotValidException | AuthorizationDeniedException e) {
+        details = e.getMessage() + "\n";
+        state = PluginState.FAILURE;
+      }
+      jobPluginInfo.incrementObjectsProcessed(state);
+      reportItem.setPluginState(state);
+      reportItem.addPluginDetails(details);
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
+    }
+  }
+
+  @Override
+  public Report afterAllExecute(IndexService index, ModelService model, StorageService storage) throws PluginException {
+    return new Report();
+  }
+
+  private IterableIndexResult<RepresentationInformation> retrieveList(IndexService index)
+    throws RequestNotValidException, GenericException {
+
+    Filter filter = new Filter();
+
+    IterableIndexResult<RepresentationInformation> indexedRepresentationInformations = index
+      .findAll(RepresentationInformation.class, filter, Collections.singletonList(RodaConstants.INDEX_UUID));
+
+    return indexedRepresentationInformations;
+  }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRepresentationInformationPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRepresentationInformationPlugin.java
@@ -180,14 +180,15 @@ public class InstanceIdentifierRepresentationInformationPlugin extends AbstractP
           model.retrieveRepresentationInformation(indexedRepresentationInformation.getId()), cachedJob.getUsername(),
           true);
         jobPluginInfo.incrementObjectsProcessedWithSuccess();
+        reportItem.setPluginState(PluginState.SUCCESS);
       } catch (GenericException | NotFoundException | RequestNotValidException | AuthorizationDeniedException e) {
         details = e.getMessage() + "\n";
         jobPluginInfo.incrementObjectsProcessedWithFailure();
         reportItem.setPluginState(PluginState.FAILURE);
         reportItem.addPluginDetails(details);
-        pluginReport.addReport(reportItem);
-        PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
       }
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
   }
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRiskIncidencePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRiskIncidencePlugin.java
@@ -1,24 +1,135 @@
 package org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.exceptions.AuthorizationDeniedException;
+import org.roda.core.data.exceptions.GenericException;
+import org.roda.core.data.exceptions.InvalidParameterException;
+import org.roda.core.data.exceptions.NotFoundException;
+import org.roda.core.data.exceptions.RequestNotValidException;
+import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.index.filter.Filter;
+import org.roda.core.data.v2.jobs.Job;
+import org.roda.core.data.v2.jobs.PluginParameter;
+import org.roda.core.data.v2.jobs.PluginState;
+import org.roda.core.data.v2.jobs.PluginType;
+import org.roda.core.data.v2.jobs.Report;
 import org.roda.core.data.v2.risks.RiskIncidence;
+import org.roda.core.index.IndexService;
+import org.roda.core.index.utils.IterableIndexResult;
+import org.roda.core.model.ModelService;
+import org.roda.core.plugins.AbstractPlugin;
 import org.roda.core.plugins.Plugin;
+import org.roda.core.plugins.PluginException;
+import org.roda.core.plugins.RODAObjectsProcessingLogic;
+import org.roda.core.plugins.orchestrate.JobPluginInfo;
+import org.roda.core.plugins.plugins.PluginHelper;
+import org.roda.core.storage.StorageService;
+import org.roda.core.storage.utils.RODAInstanceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Tiago Fraga <tfraga@keep.pt>
  */
 
-public class InstanceIdentifierRiskIncidencePlugin extends InstanceIdentifierRodaEntityPlugin<RiskIncidence> {
+public class InstanceIdentifierRiskIncidencePlugin extends AbstractPlugin<RiskIncidence> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierRiskIncidencePlugin.class);
+  private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
+
+  static {
+    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER,
+      new PluginParameter(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, "Instance Identifier",
+        PluginParameter.PluginParameterType.STRING, RODAInstanceUtils.retrieveLocalInstanceIdentifierToPlugin(), true,
+        true, "Identifier from the RODA local instance"));
+  }
+
+  private String instanceId;
+
+  @Override
+  public String getVersionImpl() {
+    return "1.0";
+  }
+
   @Override
   public String getName() {
     return "Risk Incidence instance identifier";
   }
 
   @Override
-  public String getVersionImpl() {
-    return "1.0";
+  public String getDescription() {
+    return "Add the instance identifier on the data that exists on the storage as also on the index. "
+      + "If an object already has an instance identifier it will be updated by the new one. "
+      + "This task aims to help the synchronization between a RODA central instance and the RODA local instance, "
+      + "since when an local object is accessed in RODA Central it should have the instance identifier in order to "
+      + "inform from which source is it from.";
+  }
+
+  @Override
+  public List<PluginParameter> getParameters() {
+    ArrayList<PluginParameter> parameters = new ArrayList<>();
+    parameters.add(pluginParameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER));
+    return parameters;
+  }
+
+  @Override
+  public void setParameterValues(Map<String, String> parameters) throws InvalidParameterException {
+    super.setParameterValues(parameters);
+    if (parameters != null && parameters.containsKey(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER)) {
+      instanceId = parameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER);
+    }
+  }
+
+  @Override
+  public RodaConstants.PreservationEventType getPreservationEventType() {
+    return RodaConstants.PreservationEventType.UPDATE;
+  }
+
+  @Override
+  public String getPreservationEventDescription() {
+    return "Updated the instance identifier";
+  }
+
+  @Override
+  public String getPreservationEventSuccessMessage() {
+    return "The instance identifier was updated successfully";
+  }
+
+  @Override
+  public String getPreservationEventFailureMessage() {
+    return "Could not update the instance identifier";
+  }
+
+  @Override
+  public PluginType getType() {
+    return PluginType.INTERNAL;
+  }
+
+  @Override
+  public List<String> getCategories() {
+    return Arrays.asList(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE);
+  }
+
+  @Override
+  public boolean areParameterValuesValid() {
+    return false;
+  }
+
+  @Override
+  public void init() throws PluginException {
+    // do nothing
+  }
+
+  @Override
+  public void shutdown() {
+    // do nothing
   }
 
   @Override
@@ -29,6 +140,67 @@ public class InstanceIdentifierRiskIncidencePlugin extends InstanceIdentifierRod
   @Override
   public List<Class<RiskIncidence>> getObjectClasses() {
     return Arrays.asList(RiskIncidence.class);
+  }
+
+  @Override
+  public Report beforeAllExecute(IndexService index, ModelService model, StorageService storage)
+    throws PluginException {
+    return new Report();
+  }
+
+  @Override
+  public Report execute(IndexService index, ModelService model, StorageService storage,
+    List<LiteOptionalWithCause> list) throws PluginException {
+    return PluginHelper.processObjects(this, new RODAObjectsProcessingLogic<RiskIncidence>() {
+      @Override
+      public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
+        JobPluginInfo jobPluginInfo, Plugin<RiskIncidence> plugin, List<RiskIncidence> lites) {
+        try {
+          modifyInstanceId(model, index, cachedJob, report, jobPluginInfo);
+        } catch (RequestNotValidException | GenericException | NotFoundException e) {
+          LOGGER.error("Could not modify Instance ID's in objects");
+        }
+      }
+    }, index, model, storage, list);
+  }
+
+  private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
+    JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
+    PluginState state = PluginState.SUCCESS;
+    String details = "";
+
+    // Get RiskIncidences from index
+    IterableIndexResult<RiskIncidence> indexedRiskIncidences = retrieveList(index);
+
+    for (RiskIncidence indexedRiskIncidence : indexedRiskIncidences) {
+      Report reportItem = PluginHelper.initPluginReportItem(this, indexedRiskIncidence.getId(), RiskIncidence.class);
+      try {
+        model.updateRiskIncidenceInstanceId(model.retrieveRiskIncidence(indexedRiskIncidence.getId()), true);
+      } catch (GenericException | AuthorizationDeniedException e) {
+        details = e.getMessage() + "\n";
+        state = PluginState.FAILURE;
+      }
+      jobPluginInfo.incrementObjectsProcessed(state);
+      reportItem.setPluginState(state);
+      reportItem.addPluginDetails(details);
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
+    }
+  }
+
+  @Override
+  public Report afterAllExecute(IndexService index, ModelService model, StorageService storage) throws PluginException {
+    return new Report();
+  }
+
+  private IterableIndexResult<RiskIncidence> retrieveList(IndexService index)
+    throws RequestNotValidException, GenericException {
+    Filter filter = new Filter();
+
+    IterableIndexResult<RiskIncidence> indexedRiskIncidences = index.findAll(RiskIncidence.class, filter,
+      Collections.singletonList(RodaConstants.INDEX_UUID));
+
+    return indexedRiskIncidences;
   }
 
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRiskIncidencePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRiskIncidencePlugin.java
@@ -168,25 +168,41 @@ public class InstanceIdentifierRiskIncidencePlugin extends AbstractPlugin<Void> 
   private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
     JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
     String details = "";
+    PluginState pluginState = PluginState.SKIPPED;
+    int countFail = 0;
+    int countSuccess = 0;
 
     // Get RiskIncidences from index
     IterableIndexResult<RiskIncidence> indexedRiskIncidences = retrieveList(index);
 
+    Report reportItem = PluginHelper.initPluginReportItem(this, cachedJob.getId(), Job.class);
+    PluginHelper.updatePartialJobReport(this, model, reportItem, false, cachedJob);
+
     for (RiskIncidence indexedRiskIncidence : indexedRiskIncidences) {
-      Report reportItem = PluginHelper.initPluginReportItem(this, indexedRiskIncidence.getId(), RiskIncidence.class);
       try {
         model.updateRiskIncidenceInstanceId(model.retrieveRiskIncidence(indexedRiskIncidence.getId()), true);
-        jobPluginInfo.incrementObjectsProcessedWithSuccess();
-        reportItem.setPluginState(PluginState.SUCCESS);
+        pluginState = PluginState.SUCCESS;
+        countSuccess++;
       } catch (GenericException | AuthorizationDeniedException e) {
         details = e.getMessage() + "\n";
-        jobPluginInfo.incrementObjectsProcessedWithFailure();
-        reportItem.setPluginState(PluginState.FAILURE);
-        reportItem.addPluginDetails(details);
+        pluginState = PluginState.FAILURE;
+        countFail++;
       }
-      pluginReport.addReport(reportItem);
-      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
+
+    if (countFail > 0) {
+      details = "Updated the instance identifier on " + countSuccess + " Risk incidences and failed to update "
+        + countFail;
+    } else if (countSuccess > 0) {
+      details = "Updated the instance identifier on " + countSuccess + " Risk incidences event";
+    }
+
+    reportItem.setPluginDetails(details);
+
+    jobPluginInfo.incrementObjectsProcessed(pluginState);
+    reportItem.setPluginState(pluginState);
+    pluginReport.addReport(reportItem);
+    PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRiskIncidencePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRiskIncidencePlugin.java
@@ -14,6 +14,7 @@ import org.roda.core.data.exceptions.InvalidParameterException;
 import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.Void;
 import org.roda.core.data.v2.index.filter.Filter;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.PluginParameter;
@@ -27,7 +28,7 @@ import org.roda.core.model.ModelService;
 import org.roda.core.plugins.AbstractPlugin;
 import org.roda.core.plugins.Plugin;
 import org.roda.core.plugins.PluginException;
-import org.roda.core.plugins.RODAObjectsProcessingLogic;
+import org.roda.core.plugins.RODAProcessingLogic;
 import org.roda.core.plugins.orchestrate.JobPluginInfo;
 import org.roda.core.plugins.plugins.PluginHelper;
 import org.roda.core.storage.StorageService;
@@ -39,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * @author Tiago Fraga <tfraga@keep.pt>
  */
 
-public class InstanceIdentifierRiskIncidencePlugin extends AbstractPlugin<RiskIncidence> {
+public class InstanceIdentifierRiskIncidencePlugin extends AbstractPlugin<Void> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierRiskIncidencePlugin.class);
   private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
@@ -133,13 +134,13 @@ public class InstanceIdentifierRiskIncidencePlugin extends AbstractPlugin<RiskIn
   }
 
   @Override
-  public Plugin<RiskIncidence> cloneMe() {
+  public Plugin<Void> cloneMe() {
     return new InstanceIdentifierRiskIncidencePlugin();
   }
 
   @Override
-  public List<Class<RiskIncidence>> getObjectClasses() {
-    return Arrays.asList(RiskIncidence.class);
+  public List<Class<Void>> getObjectClasses() {
+    return Arrays.asList(Void.class);
   }
 
   @Override
@@ -151,22 +152,21 @@ public class InstanceIdentifierRiskIncidencePlugin extends AbstractPlugin<RiskIn
   @Override
   public Report execute(IndexService index, ModelService model, StorageService storage,
     List<LiteOptionalWithCause> list) throws PluginException {
-    return PluginHelper.processObjects(this, new RODAObjectsProcessingLogic<RiskIncidence>() {
+    return PluginHelper.processVoids(this, new RODAProcessingLogic<Void>() {
       @Override
       public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
-        JobPluginInfo jobPluginInfo, Plugin<RiskIncidence> plugin, List<RiskIncidence> lites) {
+        JobPluginInfo jobPluginInfo, Plugin<Void> plugin) throws PluginException {
         try {
           modifyInstanceId(model, index, cachedJob, report, jobPluginInfo);
         } catch (RequestNotValidException | GenericException | NotFoundException e) {
           LOGGER.error("Could not modify Instance ID's in objects");
         }
       }
-    }, index, model, storage, list);
+    }, index, model, storage);
   }
 
   private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
     JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
-    PluginState state = PluginState.SUCCESS;
     String details = "";
 
     // Get RiskIncidences from index
@@ -176,15 +176,15 @@ public class InstanceIdentifierRiskIncidencePlugin extends AbstractPlugin<RiskIn
       Report reportItem = PluginHelper.initPluginReportItem(this, indexedRiskIncidence.getId(), RiskIncidence.class);
       try {
         model.updateRiskIncidenceInstanceId(model.retrieveRiskIncidence(indexedRiskIncidence.getId()), true);
+        jobPluginInfo.incrementObjectsProcessedWithSuccess();
       } catch (GenericException | AuthorizationDeniedException e) {
         details = e.getMessage() + "\n";
-        state = PluginState.FAILURE;
+        jobPluginInfo.incrementObjectsProcessedWithFailure();
+        reportItem.setPluginState(PluginState.FAILURE);
+        reportItem.addPluginDetails(details);
+        pluginReport.addReport(reportItem);
+        PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
       }
-      jobPluginInfo.incrementObjectsProcessed(state);
-      reportItem.setPluginState(state);
-      reportItem.addPluginDetails(details);
-      pluginReport.addReport(reportItem);
-      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
   }
 
@@ -197,10 +197,7 @@ public class InstanceIdentifierRiskIncidencePlugin extends AbstractPlugin<RiskIn
     throws RequestNotValidException, GenericException {
     Filter filter = new Filter();
 
-    IterableIndexResult<RiskIncidence> indexedRiskIncidences = index.findAll(RiskIncidence.class, filter,
-      Collections.singletonList(RodaConstants.INDEX_UUID));
-
-    return indexedRiskIncidences;
+    return index.findAll(RiskIncidence.class, filter, Collections.singletonList(RodaConstants.INDEX_UUID));
   }
 
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRiskPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRiskPlugin.java
@@ -14,6 +14,7 @@ import org.roda.core.data.exceptions.InvalidParameterException;
 import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.Void;
 import org.roda.core.data.v2.index.filter.Filter;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.PluginParameter;
@@ -28,7 +29,7 @@ import org.roda.core.model.ModelService;
 import org.roda.core.plugins.AbstractPlugin;
 import org.roda.core.plugins.Plugin;
 import org.roda.core.plugins.PluginException;
-import org.roda.core.plugins.RODAObjectsProcessingLogic;
+import org.roda.core.plugins.RODAProcessingLogic;
 import org.roda.core.plugins.orchestrate.JobPluginInfo;
 import org.roda.core.plugins.plugins.PluginHelper;
 import org.roda.core.storage.StorageService;
@@ -40,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * @author Tiago Fraga <tfraga@keep.pt>
  */
 
-public class InstanceIdentifierRiskPlugin extends AbstractPlugin<Risk> {
+public class InstanceIdentifierRiskPlugin extends AbstractPlugin<Void> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierRiskPlugin.class);
   private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
@@ -134,13 +135,13 @@ public class InstanceIdentifierRiskPlugin extends AbstractPlugin<Risk> {
   }
 
   @Override
-  public Plugin<Risk> cloneMe() {
+  public Plugin<Void> cloneMe() {
     return new InstanceIdentifierRiskPlugin();
   }
 
   @Override
-  public List<Class<Risk>> getObjectClasses() {
-    return Arrays.asList(Risk.class);
+  public List<Class<Void>> getObjectClasses() {
+    return Arrays.asList(Void.class);
   }
 
   @Override
@@ -152,22 +153,21 @@ public class InstanceIdentifierRiskPlugin extends AbstractPlugin<Risk> {
   @Override
   public Report execute(IndexService index, ModelService model, StorageService storage,
     List<LiteOptionalWithCause> list) throws PluginException {
-    return PluginHelper.processObjects(this, new RODAObjectsProcessingLogic<Risk>() {
+    return PluginHelper.processVoids(this, new RODAProcessingLogic<Void>() {
       @Override
       public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
-        JobPluginInfo jobPluginInfo, Plugin<Risk> plugin, List<Risk> lites) {
+        JobPluginInfo jobPluginInfo, Plugin<Void> plugin) throws PluginException {
         try {
           modifyInstanceId(model, index, cachedJob, report, jobPluginInfo);
         } catch (RequestNotValidException | GenericException | NotFoundException e) {
           LOGGER.error("Could not modify Instance ID's in objects");
         }
       }
-    }, index, model, storage, list);
+    }, index, model, storage);
   }
 
   private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
     JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
-    PluginState state = PluginState.SUCCESS;
     String details = "";
 
     // Get Risks from index
@@ -177,15 +177,15 @@ public class InstanceIdentifierRiskPlugin extends AbstractPlugin<Risk> {
       Report reportItem = PluginHelper.initPluginReportItem(this, indexedRisk.getId(), Risk.class);
       try {
         model.updateRiskInstanceId(model.retrieveRisk(indexedRisk.getId()), true);
+        jobPluginInfo.incrementObjectsProcessedWithSuccess();
       } catch (GenericException | AuthorizationDeniedException e) {
         details = e.getMessage() + "\n";
-        state = PluginState.FAILURE;
+        jobPluginInfo.incrementObjectsProcessedWithFailure();
+        reportItem.setPluginState(PluginState.FAILURE);
+        reportItem.addPluginDetails(details);
+        pluginReport.addReport(reportItem);
+        PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
       }
-      jobPluginInfo.incrementObjectsProcessed(state);
-      reportItem.setPluginState(state);
-      reportItem.addPluginDetails(details);
-      pluginReport.addReport(reportItem);
-      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
   }
 
@@ -196,12 +196,8 @@ public class InstanceIdentifierRiskPlugin extends AbstractPlugin<Risk> {
 
   private IterableIndexResult<IndexedRisk> retrieveList(IndexService index)
     throws RequestNotValidException, GenericException {
-
     Filter filter = new Filter();
 
-    IterableIndexResult<IndexedRisk> indexedRisks = index.findAll(IndexedRisk.class, filter,
-      Collections.singletonList(RodaConstants.INDEX_UUID));
-
-    return indexedRisks;
+    return index.findAll(IndexedRisk.class, filter, Collections.singletonList(RodaConstants.INDEX_UUID));
   }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRiskPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRiskPlugin.java
@@ -178,14 +178,15 @@ public class InstanceIdentifierRiskPlugin extends AbstractPlugin<Void> {
       try {
         model.updateRiskInstanceId(model.retrieveRisk(indexedRisk.getId()), true);
         jobPluginInfo.incrementObjectsProcessedWithSuccess();
+        reportItem.setPluginState(PluginState.SUCCESS);
       } catch (GenericException | AuthorizationDeniedException e) {
         details = e.getMessage() + "\n";
         jobPluginInfo.incrementObjectsProcessedWithFailure();
         reportItem.setPluginState(PluginState.FAILURE);
         reportItem.addPluginDetails(details);
-        pluginReport.addReport(reportItem);
-        PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
       }
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
     }
   }
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRiskPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRiskPlugin.java
@@ -1,24 +1,136 @@
 package org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.exceptions.AuthorizationDeniedException;
+import org.roda.core.data.exceptions.GenericException;
+import org.roda.core.data.exceptions.InvalidParameterException;
+import org.roda.core.data.exceptions.NotFoundException;
+import org.roda.core.data.exceptions.RequestNotValidException;
+import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.index.filter.Filter;
+import org.roda.core.data.v2.jobs.Job;
+import org.roda.core.data.v2.jobs.PluginParameter;
+import org.roda.core.data.v2.jobs.PluginState;
+import org.roda.core.data.v2.jobs.PluginType;
+import org.roda.core.data.v2.jobs.Report;
+import org.roda.core.data.v2.risks.IndexedRisk;
 import org.roda.core.data.v2.risks.Risk;
+import org.roda.core.index.IndexService;
+import org.roda.core.index.utils.IterableIndexResult;
+import org.roda.core.model.ModelService;
+import org.roda.core.plugins.AbstractPlugin;
 import org.roda.core.plugins.Plugin;
+import org.roda.core.plugins.PluginException;
+import org.roda.core.plugins.RODAObjectsProcessingLogic;
+import org.roda.core.plugins.orchestrate.JobPluginInfo;
+import org.roda.core.plugins.plugins.PluginHelper;
+import org.roda.core.storage.StorageService;
+import org.roda.core.storage.utils.RODAInstanceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Tiago Fraga <tfraga@keep.pt>
  */
 
-public class InstanceIdentifierRiskPlugin extends InstanceIdentifierRodaEntityPlugin<Risk> {
+public class InstanceIdentifierRiskPlugin extends AbstractPlugin<Risk> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierRiskPlugin.class);
+  private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
+
+  static {
+    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER,
+      new PluginParameter(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, "Instance Identifier",
+        PluginParameter.PluginParameterType.STRING, RODAInstanceUtils.retrieveLocalInstanceIdentifierToPlugin(), true,
+        true, "Identifier from the RODA local instance"));
+  }
+
+  private String instanceId;
+
+  @Override
+  public String getVersionImpl() {
+    return "1.0";
+  }
+
   @Override
   public String getName() {
     return "Risk instance identifier";
   }
 
   @Override
-  public String getVersionImpl() {
-    return "1.0";
+  public String getDescription() {
+    return "Add the instance identifier on the data that exists on the storage as also on the index. "
+      + "If an object already has an instance identifier it will be updated by the new one. "
+      + "This task aims to help the synchronization between a RODA central instance and the RODA local instance, "
+      + "since when an local object is accessed in RODA Central it should have the instance identifier in order to "
+      + "inform from which source is it from.";
+  }
+
+  @Override
+  public List<PluginParameter> getParameters() {
+    ArrayList<PluginParameter> parameters = new ArrayList<>();
+    parameters.add(pluginParameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER));
+    return parameters;
+  }
+
+  @Override
+  public void setParameterValues(Map<String, String> parameters) throws InvalidParameterException {
+    super.setParameterValues(parameters);
+    if (parameters != null && parameters.containsKey(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER)) {
+      instanceId = parameters.get(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER);
+    }
+  }
+
+  @Override
+  public RodaConstants.PreservationEventType getPreservationEventType() {
+    return RodaConstants.PreservationEventType.UPDATE;
+  }
+
+  @Override
+  public String getPreservationEventDescription() {
+    return "Updated the instance identifier";
+  }
+
+  @Override
+  public String getPreservationEventSuccessMessage() {
+    return "The instance identifier was updated successfully";
+  }
+
+  @Override
+  public String getPreservationEventFailureMessage() {
+    return "Could not update the instance identifier";
+  }
+
+  @Override
+  public PluginType getType() {
+    return PluginType.INTERNAL;
+  }
+
+  @Override
+  public List<String> getCategories() {
+    return Arrays.asList(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE);
+  }
+
+  @Override
+  public boolean areParameterValuesValid() {
+    return false;
+  }
+
+  @Override
+  public void init() throws PluginException {
+    // do nothing
+  }
+
+  @Override
+  public void shutdown() {
+    // do nothing
   }
 
   @Override
@@ -29,5 +141,67 @@ public class InstanceIdentifierRiskPlugin extends InstanceIdentifierRodaEntityPl
   @Override
   public List<Class<Risk>> getObjectClasses() {
     return Arrays.asList(Risk.class);
+  }
+
+  @Override
+  public Report beforeAllExecute(IndexService index, ModelService model, StorageService storage)
+    throws PluginException {
+    return new Report();
+  }
+
+  @Override
+  public Report execute(IndexService index, ModelService model, StorageService storage,
+    List<LiteOptionalWithCause> list) throws PluginException {
+    return PluginHelper.processObjects(this, new RODAObjectsProcessingLogic<Risk>() {
+      @Override
+      public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
+        JobPluginInfo jobPluginInfo, Plugin<Risk> plugin, List<Risk> lites) {
+        try {
+          modifyInstanceId(model, index, cachedJob, report, jobPluginInfo);
+        } catch (RequestNotValidException | GenericException | NotFoundException e) {
+          LOGGER.error("Could not modify Instance ID's in objects");
+        }
+      }
+    }, index, model, storage, list);
+  }
+
+  private void modifyInstanceId(ModelService model, IndexService index, Job cachedJob, Report pluginReport,
+    JobPluginInfo jobPluginInfo) throws RequestNotValidException, GenericException, NotFoundException {
+    PluginState state = PluginState.SUCCESS;
+    String details = "";
+
+    // Get Risks from index
+    IterableIndexResult<IndexedRisk> indexedRisks = retrieveList(index);
+
+    for (IndexedRisk indexedRisk : indexedRisks) {
+      Report reportItem = PluginHelper.initPluginReportItem(this, indexedRisk.getId(), Risk.class);
+      try {
+        model.updateRiskInstanceId(model.retrieveRisk(indexedRisk.getId()), true);
+      } catch (GenericException | AuthorizationDeniedException e) {
+        details = e.getMessage() + "\n";
+        state = PluginState.FAILURE;
+      }
+      jobPluginInfo.incrementObjectsProcessed(state);
+      reportItem.setPluginState(state);
+      reportItem.addPluginDetails(details);
+      pluginReport.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
+    }
+  }
+
+  @Override
+  public Report afterAllExecute(IndexService index, ModelService model, StorageService storage) throws PluginException {
+    return new Report();
+  }
+
+  private IterableIndexResult<IndexedRisk> retrieveList(IndexService index)
+    throws RequestNotValidException, GenericException {
+
+    Filter filter = new Filter();
+
+    IterableIndexResult<IndexedRisk> indexedRisks = index.findAll(IndexedRisk.class, filter,
+      Collections.singletonList(RodaConstants.INDEX_UUID));
+
+    return indexedRisks;
   }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRodaObjectPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/InstanceIdentifierRodaObjectPlugin.java
@@ -1,0 +1,146 @@
+package org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.exceptions.InvalidParameterException;
+import org.roda.core.data.v2.IsRODAObject;
+import org.roda.core.data.v2.ip.AIP;
+import org.roda.core.data.v2.ip.DIP;
+import org.roda.core.data.v2.jobs.Job;
+import org.roda.core.data.v2.jobs.PluginParameter;
+import org.roda.core.data.v2.jobs.Report;
+import org.roda.core.data.v2.notifications.Notification;
+import org.roda.core.data.v2.ri.RepresentationInformation;
+import org.roda.core.data.v2.risks.Risk;
+import org.roda.core.data.v2.risks.RiskIncidence;
+import org.roda.core.index.IndexService;
+import org.roda.core.model.ModelService;
+import org.roda.core.plugins.Plugin;
+import org.roda.core.plugins.PluginException;
+import org.roda.core.plugins.plugins.multiple.DefaultMultipleStepPlugin;
+import org.roda.core.plugins.plugins.multiple.Step;
+import org.roda.core.storage.StorageService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@author João Gomes <jgomes@keep.pt>}.
+ */
+public class InstanceIdentifierRodaObjectPlugin extends DefaultMultipleStepPlugin<IsRODAObject> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIdentifierRodaObjectPlugin.class);
+
+  private Map<String, PluginParameter> pluginParameters = new HashMap<>();
+  private static List<Step> steps = new ArrayList<>();
+
+  static {
+    steps.add(new Step(InstanceIdentifierAIPPlugin.class.getName(), AIP.class, "", true, true));
+    steps.add(new Step(InstanceIdentifierDIPPlugin.class.getName(), DIP.class, "", true, true));
+    steps.add(new Step(InstanceIdentifierRepresentationInformationPlugin.class.getName(),
+      RepresentationInformation.class, "", true, true));
+    steps.add(new Step(InstanceIdentifierNotificationPlugin.class.getName(), Notification.class, "", true, true));
+    steps.add(new Step(InstanceIdentifierRiskPlugin.class.getName(), Risk.class, "", true, true));
+    steps.add(new Step(InstanceIdentifierRiskIncidencePlugin.class.getName(), RiskIncidence.class, "", true, true));
+    steps.add(new Step(InstanceIdentifierJobPlugin.class.getName(), Job.class, "", true, true));
+
+  }
+
+  @Override
+  public String getVersionImpl() {
+    return "1.0";
+  }
+
+  @Override
+  public String getName() {
+    return "RODA Object instance identifier";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Add the instance identifier on the data that exists on the storage as also on the index. "
+      + "If an object already has an instance identifier it will be updated by the new one. "
+      + "This task aims to help the synchronization between a RODA central instance and the RODA local instance, "
+      + "since when an local object is accessed in RODA Central it should have the instance identifier in order to "
+      + "inform from which source is it from.";
+  }
+
+  @Override
+  public RodaConstants.PreservationEventType getPreservationEventType() {
+    return RodaConstants.PreservationEventType.UPDATE;
+  }
+
+  @Override
+  public String getPreservationEventDescription() {
+    return "Updated the instance identifier";
+  }
+
+  @Override
+  public String getPreservationEventSuccessMessage() {
+    return "The instance identifier was updated successfully";
+  }
+
+  @Override
+  public String getPreservationEventFailureMessage() {
+    return "Could not update the instance identifier";
+  }
+
+  @Override
+  public List<String> getCategories() {
+    return Arrays.asList(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE);
+  }
+
+  @Override
+  public Plugin<IsRODAObject> cloneMe() {
+    return new InstanceIdentifierRodaObjectPlugin();
+  }
+
+  @Override
+  public boolean areParameterValuesValid() {
+    return true;
+  }
+
+  @Override
+  public List<Class<IsRODAObject>> getObjectClasses() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Report afterAllExecute(IndexService index, ModelService model, StorageService storage) throws PluginException {
+    return null;
+  }
+
+  @Override
+  public void setTotalSteps() {
+    this.totalSteps = steps.size();
+  }
+
+  @Override
+  public List<Step> getPluginSteps() {
+    return steps;
+  }
+
+  @Override
+  public PluginParameter getPluginParameter(String pluginParameterId) {
+    if (pluginParameters.get(pluginParameterId) != null) {
+      return pluginParameters.get(pluginParameterId);
+    } else {
+      return new PluginParameter();
+    }
+  }
+
+  public void setParameterValues(Map<String, String> parameters) throws InvalidParameterException {
+    setTotalSteps();
+    super.setParameterValues(parameters);
+  }
+
+  @Override
+  public Report beforeAllExecute(IndexService index, ModelService model, StorageService storage)
+    throws PluginException {
+    return new Report();
+  }
+}

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/RegisterPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/instanceIdentifier/RegisterPlugin.java
@@ -158,7 +158,9 @@ public class RegisterPlugin extends AbstractPlugin<Void> {
   private void registerLocalInstance(ModelService model, Job cachedJob, Report pluginReport,
     JobPluginInfo jobPluginInfo) {
 
-    Report reportItem = PluginHelper.initPluginReportItem(this, instanceId, Job.class);
+    Report reportItem = PluginHelper.initPluginReportItem(this, cachedJob.getId(), Job.class);
+    PluginHelper.updatePartialJobReport(this, model, reportItem, false, cachedJob);
+
     try {
       LocalInstance localInstance = RodaCoreFactory.getLocalInstance();
       AccessToken accessToken = TokenManager.getInstance().getAccessToken(localInstance);

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/proccess/RequestSyncBundlePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/proccess/RequestSyncBundlePlugin.java
@@ -163,7 +163,8 @@ public class RequestSyncBundlePlugin extends AbstractPlugin<Void> {
           final Path bundleWorkingDir = SyncUtils.extractBundle(localInstance.getId(), path);
           final int jobs = createJobs(localInstance.getId(), index);
           final BundleState bundleState = SyncUtils.getIncomingBundleState(localInstance.getId());
-          final int imported = SyncUtils.importStorage(storage, bundleWorkingDir, bundleState, jobPluginInfo, false);
+          final int imported = SyncUtils.importStorage(model, index, storage, cachedJob, bundleWorkingDir, bundleState,
+            jobPluginInfo, report, false);
 
           ImportUtils.deleteBundleEntities(model, index, cachedJob, this, jobPluginInfo, localInstance,
             bundleWorkingDir, bundleState.getValidationEntityList(), report);

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/proccess/SynchronizeInstancePlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/internal/synchronization/proccess/SynchronizeInstancePlugin.java
@@ -52,7 +52,6 @@ public class SynchronizeInstancePlugin extends DefaultMultipleStepPlugin<IsRODAO
   private Map<String, PluginParameter> pluginParameters = new HashMap<>();
   private static List<Step> steps = new ArrayList<>();
 
-
   static {
 
     steps.add(new Step(AipPackagePlugin.class.getName(), AIP.class, "", true, true));
@@ -181,6 +180,7 @@ public class SynchronizeInstancePlugin extends DefaultMultipleStepPlugin<IsRODAO
   @Override
   public void setParameterValues(Map<String, String> parameters) throws InvalidParameterException {
     setTotalSteps();
+    setSourceObjectsCount(1);
     super.setParameterValues(parameters);
 
     if (RodaConstants.DistributedModeType.LOCAL.equals(RodaCoreFactory.getDistributedModeType())) {

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/DefaultMultipleStepPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/DefaultMultipleStepPlugin.java
@@ -1,9 +1,9 @@
 package org.roda.core.plugins.plugins.multiple;
 
 import java.util.List;
-
 import java.util.Map;
-import org.roda.core.RodaCoreFactory;
+import java.util.Optional;
+
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.exceptions.InvalidParameterException;
 import org.roda.core.data.exceptions.JobException;
@@ -74,10 +74,14 @@ public abstract class DefaultMultipleStepPlugin<T extends IsRODAObject> extends 
     try {
       boolean updateMetaPluginInformation = true;
       final MultipleJobPluginInfo jobPluginInfo = (MultipleJobPluginInfo) outerJobPluginInfo;
-      PluginHelper.updateJobInformationAsync(this, jobPluginInfo.setTotalSteps(getTotalSteps()));
+      jobPluginInfo.setTotalSteps(getTotalSteps());
 
       List<Step> steps = getPluginSteps();
+      Optional<Integer> count = MutipleStepUtils.getTotalSourceObjectsCount(steps);
 
+      count.ifPresent(jobPluginInfo::setSourceObjectsCount);
+
+      PluginHelper.updateJobInformationAsync(this, jobPluginInfo);
       for (Step step : steps) {
         MultipleStepBundle bundle = new MultipleStepBundle(this, index, model, storage, jobPluginInfo,
           getPluginParameter(step.getParameterName()), getParameterValues(), resources, cachedJob);

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/DefaultMultipleStepPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/DefaultMultipleStepPlugin.java
@@ -100,7 +100,6 @@ public abstract class DefaultMultipleStepPlugin<T extends IsRODAObject> extends 
       jobPluginInfo.finalizeInfo();
       PluginHelper.updateJobInformationAsync(this, jobPluginInfo);
     } catch (JobException e) {
-      LOGGER.error("OKOK");
       // do nothing
     } finally {
       // remove locks if any

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/DefaultMultipleStepPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/DefaultMultipleStepPlugin.java
@@ -2,7 +2,6 @@ package org.roda.core.plugins.plugins.multiple;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.exceptions.InvalidParameterException;
@@ -33,6 +32,10 @@ public abstract class DefaultMultipleStepPlugin<T extends IsRODAObject> extends 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMultipleStepPlugin.class);
 
   protected int totalSteps;
+
+  protected int sourceObjectsCount;
+
+  private boolean sourceObjectsCountSet = false;
 
   @Override
   public void init() throws PluginException {
@@ -77,9 +80,9 @@ public abstract class DefaultMultipleStepPlugin<T extends IsRODAObject> extends 
       jobPluginInfo.setTotalSteps(getTotalSteps());
 
       List<Step> steps = getPluginSteps();
-      Optional<Integer> count = MutipleStepUtils.getTotalSourceObjectsCount(steps);
-
-      count.ifPresent(jobPluginInfo::setSourceObjectsCount);
+      if (sourceObjectsCountSet) {
+        jobPluginInfo.setSourceObjectsCount(sourceObjectsCount);
+      }
 
       PluginHelper.updateJobInformationAsync(this, jobPluginInfo);
       for (Step step : steps) {
@@ -118,6 +121,11 @@ public abstract class DefaultMultipleStepPlugin<T extends IsRODAObject> extends 
   }
 
   public abstract void setTotalSteps();
+
+  public void setSourceObjectsCount(int value) {
+    sourceObjectsCount = value;
+    sourceObjectsCountSet = true;
+  }
 
   public abstract List<Step> getPluginSteps();
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/DefaultMultipleStepPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/DefaultMultipleStepPlugin.java
@@ -97,6 +97,7 @@ public abstract class DefaultMultipleStepPlugin<T extends IsRODAObject> extends 
       jobPluginInfo.finalizeInfo();
       PluginHelper.updateJobInformationAsync(this, jobPluginInfo);
     } catch (JobException e) {
+      LOGGER.error("OKOK");
       // do nothing
     } finally {
       // remove locks if any

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/MutipleStepUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/MutipleStepUtils.java
@@ -74,17 +74,4 @@ public class MutipleStepUtils {
     }
   }
 
-  public static Optional<Integer> getTotalSourceObjectsCount(final List<Step> steps) {
-    int count = 0;
-    for (Step step : steps) {
-      if (step.getSourceObjectsCount().isPresent()) {
-        count += step.getSourceObjectsCount().get();
-      }
-    }
-    if (count == 0) {
-      return Optional.empty();
-    }
-    return Optional.of(count);
-  }
-
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/MutipleStepUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/MutipleStepUtils.java
@@ -3,6 +3,7 @@ package org.roda.core.plugins.plugins.multiple;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.roda.core.RodaCoreFactory;
 import org.roda.core.data.exceptions.InvalidParameterException;
@@ -71,6 +72,19 @@ public class MutipleStepUtils {
         jobPluginInfo.addReport(reportItem);
       }
     }
+  }
+
+  public static Optional<Integer> getTotalSourceObjectsCount(final List<Step> steps) {
+    int count = 0;
+    for (Step step : steps) {
+      if (step.getSourceObjectsCount().isPresent()) {
+        count += step.getSourceObjectsCount().get();
+      }
+    }
+    if (count == 0) {
+      return Optional.empty();
+    }
+    return Optional.of(count);
   }
 
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/Step.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/plugins/multiple/Step.java
@@ -2,6 +2,7 @@ package org.roda.core.plugins.plugins.multiple;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.roda.core.data.exceptions.JobException;
 import org.roda.core.plugins.plugins.PluginHelper;
@@ -16,6 +17,7 @@ public class Step {
   private String parameterName;
   private boolean usesCorePlugin;
   private boolean mandatory;
+  private Optional<Integer> sourceObjectsCount;
   private Map<String, String> parameters;
 
   public Step(final String pluginName, final Class<?> pluginClass, final String parameterName,
@@ -31,6 +33,7 @@ public class Step {
     this.usesCorePlugin = usesCorePlugin;
     this.mandatory = mandatory;
     this.parameters = parameters;
+    this.sourceObjectsCount = Optional.empty();
   }
 
   public String getPluginName() {
@@ -81,9 +84,18 @@ public class Step {
     this.parameters = parameters;
   }
 
+  public Optional<Integer> getSourceObjectsCount() {
+    return sourceObjectsCount;
+  }
+
+  public void setSourceObjectsCount(Optional<Integer> sourceObjectsCount) {
+    this.sourceObjectsCount = sourceObjectsCount;
+  }
+
   public void execute(MultipleStepBundle bundle) throws JobException {
     MutipleStepUtils.executePlugin(bundle, this);
     PluginHelper.updateJobInformationAsync(bundle.getPlugin(),
       bundle.getJobPluginInfo().incrementStepsCompletedByOne());
   }
+
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/controllers/RODAInstance.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/controllers/RODAInstance.java
@@ -1,6 +1,5 @@
 package org.roda.wui.api.controllers;
 
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,16 +19,15 @@ import org.roda.core.data.exceptions.JobAlreadyStartedException;
 import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.exceptions.RODAException;
 import org.roda.core.data.exceptions.RequestNotValidException;
-import org.roda.core.data.v2.accessToken.AccessToken;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.log.LogEntryState;
 import org.roda.core.data.v2.synchronization.central.DistributedInstance;
 import org.roda.core.data.v2.synchronization.central.DistributedInstanceStatus;
 import org.roda.core.data.v2.synchronization.central.DistributedInstances;
 import org.roda.core.data.v2.synchronization.local.LocalInstance;
+import org.roda.core.data.v2.synchronization.local.LocalInstanceIdentifierState;
 import org.roda.core.data.v2.user.User;
 import org.roda.core.storage.utils.RODAInstanceUtils;
-import org.roda.core.util.RESTClientUtility;
 import org.roda.wui.api.v1.utils.ObjectResponse;
 import org.roda.wui.common.ControllerAssistant;
 import org.roda.wui.common.RodaWuiController;
@@ -270,6 +268,7 @@ public class RODAInstance extends RodaWuiController {
     return responseList;
   }
 
+  // TODO: Delete this method
   public static void modifyInstanceIdOnRepository(User user, LocalInstance localInstance)
     throws AuthorizationDeniedException, GenericException, RequestNotValidException, NotFoundException {
     final ControllerAssistant controllerAssistant = new ControllerAssistant() {};
@@ -282,18 +281,8 @@ public class RODAInstance extends RodaWuiController {
 
     try {
       RODAInstanceHelper.applyInstanceIdToRodaObject(localInstance, user);
-      // RODAInstanceHelper.applyInstanceIdToAIP(localInstance, user);
-      // RODAInstanceHelper.applyInstanceIdToDIP(localInstance, user);
-      // RODAInstanceHelper.applyInstanceIdToRisk(localInstance, user);
-      // RODAInstanceHelper.applyInstanceIdToRiskIncidence(localInstance, user);
-      // RODAInstanceHelper.applyInstanceIdToRI(localInstance, user);
-      // RODAInstanceHelper.applyInstanceIdToNotification(localInstance, user);
-      // RODAInstanceHelper.applyInstanceIdToJob(localInstance, user);
-      // RODAInstanceHelper.applyInstanceIdToAIPPreservationEvent(localInstance,
-      // user);
-      // RODAInstanceHelper.applyInstanceIdToPreservationAgents(localInstance, user);
-      // RODAInstanceHelper.applyInstanceIdToRepositoryPreservationEvent(localInstance,
-      // user);
+      localInstance.setInstanceIdentifierState(LocalInstanceIdentifierState.ACTIVE);
+      RodaCoreFactory.createOrUpdateLocalInstance(localInstance);
     } catch (RODAException e) {
       state = LogEntryState.FAILURE;
       throw e;
@@ -303,7 +292,8 @@ public class RODAInstance extends RodaWuiController {
   }
 
   public static LocalInstance registerLocalInstance(User user, LocalInstance localInstance)
-    throws AuthorizationDeniedException, GenericException, AuthenticationDeniedException {
+    throws AuthorizationDeniedException, GenericException, AuthenticationDeniedException, RequestNotValidException,
+    NotFoundException {
     final ControllerAssistant controllerAssistant = new ControllerAssistant() {};
 
     // check user permissions
@@ -312,12 +302,9 @@ public class RODAInstance extends RodaWuiController {
     LogEntryState state = LogEntryState.SUCCESS;
 
     try {
-      AccessToken accessToken = TokenManager.getInstance().getAccessToken(localInstance);
-      String resource = RodaConstants.API_SEP + RodaConstants.API_REST_V1_DISTRIBUTED_INSTANCE
-        + RodaConstants.API_PATH_PARAM_DISTRIBUTED_INSTANCE_REGISTER;
-      RESTClientUtility.sendPostRequest(localInstance, null, localInstance.getCentralInstanceURL(), resource,
-        accessToken);
-      localInstance.setIsRegistered(true);
+      // Apply Identifiers
+      RODAInstanceHelper.applyInstanceIdToRodaObject(localInstance, user);
+      localInstance.setInstanceIdentifierState(LocalInstanceIdentifierState.RUNNING);
       RodaCoreFactory.createOrUpdateLocalInstance(localInstance);
       RODAInstanceUtils.createDistributedGroup(user);
       return localInstance;
@@ -457,7 +444,6 @@ public class RODAInstance extends RodaWuiController {
       controllerAssistant.registerAction(user, state);
     }
   }
-
 
   public static String removeSyncBundle(String bundleName, User user, String bundleDirectory)
     throws AuthorizationDeniedException {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/controllers/RODAInstance.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/controllers/RODAInstance.java
@@ -281,16 +281,19 @@ public class RODAInstance extends RodaWuiController {
     LogEntryState state = LogEntryState.SUCCESS;
 
     try {
-      RODAInstanceHelper.applyInstanceIdToAIP(localInstance, user);
-      RODAInstanceHelper.applyInstanceIdToDIP(localInstance, user);
-      RODAInstanceHelper.applyInstanceIdToRisk(localInstance, user);
-      RODAInstanceHelper.applyInstanceIdToRiskIncidence(localInstance, user);
-      RODAInstanceHelper.applyInstanceIdToRI(localInstance, user);
-      RODAInstanceHelper.applyInstanceIdToNotification(localInstance, user);
-      RODAInstanceHelper.applyInstanceIdToJob(localInstance, user);
-      RODAInstanceHelper.applyInstanceIdToAIPPreservationEvent(localInstance, user);
-      RODAInstanceHelper.applyInstanceIdToPreservationAgents(localInstance, user);
-      RODAInstanceHelper.applyInstanceIdToRepositoryPreservationEvent(localInstance, user);
+      RODAInstanceHelper.applyInstanceIdToRodaObject(localInstance, user);
+      // RODAInstanceHelper.applyInstanceIdToAIP(localInstance, user);
+      // RODAInstanceHelper.applyInstanceIdToDIP(localInstance, user);
+      // RODAInstanceHelper.applyInstanceIdToRisk(localInstance, user);
+      // RODAInstanceHelper.applyInstanceIdToRiskIncidence(localInstance, user);
+      // RODAInstanceHelper.applyInstanceIdToRI(localInstance, user);
+      // RODAInstanceHelper.applyInstanceIdToNotification(localInstance, user);
+      // RODAInstanceHelper.applyInstanceIdToJob(localInstance, user);
+      // RODAInstanceHelper.applyInstanceIdToAIPPreservationEvent(localInstance,
+      // user);
+      // RODAInstanceHelper.applyInstanceIdToPreservationAgents(localInstance, user);
+      // RODAInstanceHelper.applyInstanceIdToRepositoryPreservationEvent(localInstance,
+      // user);
     } catch (RODAException e) {
       state = LogEntryState.FAILURE;
       throw e;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/controllers/RODAInstanceHelper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/controllers/RODAInstanceHelper.java
@@ -22,38 +22,20 @@ import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.v2.index.IsIndexed;
 import org.roda.core.data.v2.index.filter.DateIntervalFilterParameter;
-import org.roda.core.data.v2.index.filter.EmptyKeyFilterParameter;
 import org.roda.core.data.v2.index.filter.Filter;
 import org.roda.core.data.v2.index.filter.NotSimpleFilterParameter;
-import org.roda.core.data.v2.index.filter.SimpleFilterParameter;
-import org.roda.core.data.v2.index.select.SelectedItemsFilter;
 import org.roda.core.data.v2.index.select.SelectedItemsNone;
-import org.roda.core.data.v2.ip.AIPState;
 import org.roda.core.data.v2.ip.IndexedAIP;
 import org.roda.core.data.v2.ip.IndexedDIP;
-import org.roda.core.data.v2.ip.metadata.IndexedPreservationAgent;
 import org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.PluginType;
-import org.roda.core.data.v2.notifications.Notification;
-import org.roda.core.data.v2.ri.RepresentationInformation;
-import org.roda.core.data.v2.risks.IndexedRisk;
 import org.roda.core.data.v2.risks.RiskIncidence;
 import org.roda.core.data.v2.synchronization.central.DistributedInstance;
 import org.roda.core.data.v2.synchronization.local.LocalInstance;
 import org.roda.core.data.v2.user.User;
 import org.roda.core.index.IndexService;
-import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierAIPEventPlugin;
-import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierAIPPlugin;
-import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierDIPPlugin;
-import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierJobPlugin;
-import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierNotificationPlugin;
-import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierPreservationAgentPlugin;
-import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierRepositoryEventPlugin;
-import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierRepresentationInformationPlugin;
-import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierRiskIncidencePlugin;
-import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierRiskPlugin;
-import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierRodaObjectPlugin;
+import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.LocalInstanceRegisterPlugin;
 import org.roda.core.plugins.plugins.internal.synchronization.proccess.ImportSyncBundlePlugin;
 import org.roda.core.plugins.plugins.internal.synchronization.proccess.SynchronizeInstancePlugin;
 import org.slf4j.Logger;
@@ -71,123 +53,14 @@ public class RODAInstanceHelper {
     return RodaCoreFactory.getModelService().createDistributedInstance(distributedInstance, user.getName());
   }
 
+  // TODO: Rename this method to register
   public static void applyInstanceIdToRodaObject(LocalInstance localInstance, User user)
     throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
     Map<String, String> pluginParameters = new HashMap<>();
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, localInstance.getId());
 
-    BrowserHelper.createAndExecuteInternalJob("Apply Instance Id to RODA Objects", new SelectedItemsNone<>(),
-      InstanceIdentifierRodaObjectPlugin.class, user, pluginParameters,
-      "Could not apply instance identifier to RODA Object");
-  }
-
-  public static void applyInstanceIdToAIP(LocalInstance localInstance, User user)
-    throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
-    Map<String, String> pluginParameters = new HashMap<>();
-    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, localInstance.getId());
-
-    BrowserHelper.createAndExecuteInternalJob("Apply instance identifier to AIP",
-      new SelectedItemsFilter(new Filter(new SimpleFilterParameter(RodaConstants.AIP_STATE, AIPState.ACTIVE.name())),
-        IndexedAIP.class.getName(), true),
-      InstanceIdentifierAIPPlugin.class, user, pluginParameters, "Could not apply instance identifier to AIP");
-  }
-
-  public static void applyInstanceIdToDIP(LocalInstance localInstance, User user)
-    throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
-    Map<String, String> pluginParameters = new HashMap<>();
-    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, localInstance.getId());
-
-    BrowserHelper.createAndExecuteInternalJob("Apply instance identifier to DIP",
-      new SelectedItemsFilter(new Filter(), IndexedDIP.class.getName(), true), InstanceIdentifierDIPPlugin.class, user,
-      pluginParameters, "Could not apply instance identifier to DIP");
-  }
-
-  public static void applyInstanceIdToRisk(LocalInstance localInstance, User user)
-    throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
-    Map<String, String> pluginParameters = new HashMap<>();
-    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, localInstance.getId());
-
-    BrowserHelper.createAndExecuteInternalJob("Apply instance identifier to Risk",
-      new SelectedItemsFilter(new Filter(), IndexedRisk.class.getName(), true), InstanceIdentifierRiskPlugin.class,
-      user, pluginParameters, "Could not apply instance identifier to Risk");
-  }
-
-  public static void applyInstanceIdToRiskIncidence(LocalInstance localInstance, User user)
-    throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
-    Map<String, String> pluginParameters = new HashMap<>();
-    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, localInstance.getId());
-
-    BrowserHelper.createAndExecuteInternalJob("Apply instance identifier to Risk incidence",
-      new SelectedItemsFilter(new Filter(), RiskIncidence.class.getName(), true),
-      InstanceIdentifierRiskIncidencePlugin.class, user, pluginParameters,
-      "Could not apply instance identifier to Risk incidence");
-  }
-
-  public static void applyInstanceIdToRI(LocalInstance localInstance, User user)
-    throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
-    Map<String, String> pluginParameters = new HashMap<>();
-    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, localInstance.getId());
-
-    BrowserHelper.createAndExecuteInternalJob("Apply instance identifier to Representation Information",
-      new SelectedItemsFilter(new Filter(), RepresentationInformation.class.getName(), true),
-      InstanceIdentifierRepresentationInformationPlugin.class, user, pluginParameters,
-      "Could not apply instance identifier to Representation Information");
-  }
-
-  public static void applyInstanceIdToNotification(LocalInstance localInstance, User user)
-    throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
-    Map<String, String> pluginParameters = new HashMap<>();
-    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, localInstance.getId());
-
-    BrowserHelper.createAndExecuteInternalJob("Apply instance identifier to Notification",
-      new SelectedItemsFilter(new Filter(), Notification.class.getName(), true),
-      InstanceIdentifierNotificationPlugin.class, user, pluginParameters,
-      "Could not apply instance identifier to Notification");
-  }
-
-  public static void applyInstanceIdToJob(LocalInstance localInstance, User user)
-    throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
-    Map<String, String> pluginParameters = new HashMap<>();
-    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, localInstance.getId());
-
-    BrowserHelper.createAndExecuteInternalJob("Apply instance identifier to Job",
-      new SelectedItemsFilter(new Filter(), Job.class.getName(), true), InstanceIdentifierJobPlugin.class, user,
-      pluginParameters, "Could not apply instance identifier to Job");
-  }
-
-  public static void applyInstanceIdToAIPPreservationEvent(LocalInstance localInstance, User user)
-    throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
-    Map<String, String> pluginParameters = new HashMap<>();
-    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, localInstance.getId());
-
-    BrowserHelper.createAndExecuteInternalJob("Apply instance identifier to AIP Preservation Events",
-      new SelectedItemsFilter(new Filter(new SimpleFilterParameter(RodaConstants.AIP_STATE, AIPState.ACTIVE.name())),
-        IndexedAIP.class.getName(), true),
-      InstanceIdentifierAIPEventPlugin.class, user, pluginParameters,
-      "Could not apply instance identifier to AIP Preservation Events");
-  }
-
-  public static void applyInstanceIdToRepositoryPreservationEvent(LocalInstance localInstance, User user)
-    throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
-    Map<String, String> pluginParameters = new HashMap<>();
-    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, localInstance.getId());
-
-    BrowserHelper.createAndExecuteInternalJob("Apply instance identifier to Repository Preservation Events",
-      new SelectedItemsFilter(new Filter(new EmptyKeyFilterParameter(RodaConstants.PRESERVATION_EVENT_AIP_ID)),
-        IndexedPreservationEvent.class.getName(), true),
-      InstanceIdentifierRepositoryEventPlugin.class, user, pluginParameters,
-      "Could not apply instance identifier to Repository Preservation Events");
-  }
-
-  public static void applyInstanceIdToPreservationAgents(LocalInstance localInstance, User user)
-    throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
-    Map<String, String> pluginParameters = new HashMap<>();
-    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, localInstance.getId());
-
-    BrowserHelper.createAndExecuteInternalJob("Apply instance identifier to Preservation Agents",
-      new SelectedItemsFilter(new Filter(), IndexedPreservationAgent.class.getName(), true),
-      InstanceIdentifierPreservationAgentPlugin.class, user, pluginParameters,
-      "Could not apply instance identifier to Preservation Agents");
+    BrowserHelper.createAndExecuteInternalJob("Local Instance Register", new SelectedItemsNone<>(),
+      LocalInstanceRegisterPlugin.class, user, pluginParameters, "Could not register the localInstance");
   }
 
   public static Job synchronizeBundle(User user, LocalInstance localInstance)

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/controllers/RODAInstanceHelper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/controllers/RODAInstanceHelper.java
@@ -53,6 +53,7 @@ import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier
 import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierRepresentationInformationPlugin;
 import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierRiskIncidencePlugin;
 import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierRiskPlugin;
+import org.roda.core.plugins.plugins.internal.synchronization.instanceIdentifier.InstanceIdentifierRodaObjectPlugin;
 import org.roda.core.plugins.plugins.internal.synchronization.proccess.ImportSyncBundlePlugin;
 import org.roda.core.plugins.plugins.internal.synchronization.proccess.SynchronizeInstancePlugin;
 import org.slf4j.Logger;
@@ -68,6 +69,16 @@ public class RODAInstanceHelper {
     throws GenericException, AuthorizationDeniedException, AlreadyExistsException, NotFoundException,
     RequestNotValidException, IllegalOperationException {
     return RodaCoreFactory.getModelService().createDistributedInstance(distributedInstance, user.getName());
+  }
+
+  public static void applyInstanceIdToRodaObject(LocalInstance localInstance, User user)
+    throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
+    Map<String, String> pluginParameters = new HashMap<>();
+    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_INSTANCE_IDENTIFIER, localInstance.getId());
+
+    BrowserHelper.createAndExecuteInternalJob("Apply Instance Id to RODA Objects", new SelectedItemsNone<>(),
+      InstanceIdentifierRodaObjectPlugin.class, user, pluginParameters,
+      "Could not apply instance identifier to RODA Object");
   }
 
   public static void applyInstanceIdToAIP(LocalInstance localInstance, User user)

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowserService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowserService.java
@@ -560,7 +560,7 @@ public interface BrowserService extends RemoteService {
     throws AuthorizationDeniedException, GenericException, AuthenticationDeniedException;
 
   LocalInstance registerLocalInstance(LocalInstance localInstance)
-      throws AuthorizationDeniedException, GenericException, AuthenticationDeniedException;
+          throws AuthorizationDeniedException, GenericException, AuthenticationDeniedException, RequestNotValidException, NotFoundException;
 
   Job synchronizeBundle(LocalInstance localInstance)
     throws AuthorizationDeniedException, GenericException, NotFoundException, RequestNotValidException;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/HtmlSnippetUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/HtmlSnippetUtils.java
@@ -906,6 +906,10 @@ public class HtmlSnippetUtils {
         b.append(SafeHtmlUtils.fromSafeConstant(OPEN_SPAN_CLASS_LABEL_SUCCESS));
         b.append(
           SafeHtmlUtils.fromString(messages.localInstanceIdentifierState(localInstance.getInstanceIdentifierState())));
+      } else if (localInstance.getInstanceIdentifierState().equals(LocalInstanceIdentifierState.RUNNING)) {
+        b.append(SafeHtmlUtils.fromSafeConstant(OPEN_SPAN_CLASS_LABEL_INFO));
+        b.append(
+          SafeHtmlUtils.fromString(messages.localInstanceIdentifierState(localInstance.getInstanceIdentifierState())));
       } else {
         b.append(SafeHtmlUtils.fromSafeConstant(OPEN_SPAN_CLASS_LABEL_DEFAULT));
         b.append(

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/ShowLocalInstanceConfiguration.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/distributed/ShowLocalInstanceConfiguration.ui.xml
@@ -75,9 +75,6 @@
                         <g:Button addStyleNames="btn btn-block btn-play" ui:field="buttonRegister">
                             <ui:text from='{messages.registerLocalInstanceConfigurationButton}'/>
                         </g:Button>
-                        <g:Button addStyleNames="btn btn-block btn-play" ui:field="buttonApplyId">
-                            <ui:text from='{messages.applyInstanceId}'/>
-                        </g:Button>
 <!--                        <g:Button addStyleNames="btn btn-block btn-play" ui:field="buttonCreateBundle">-->
 <!--                            <ui:text from='{messages.createBundleButton}'/>-->
 <!--                        </g:Button>-->

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/server/browse/BrowserServiceImpl.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/server/browse/BrowserServiceImpl.java
@@ -1399,7 +1399,7 @@ public class BrowserServiceImpl extends RemoteServiceServlet implements BrowserS
 
   @Override
   public LocalInstance registerLocalInstance(LocalInstance localInstance)
-    throws AuthorizationDeniedException, GenericException, AuthenticationDeniedException {
+          throws AuthorizationDeniedException, GenericException, AuthenticationDeniedException, RequestNotValidException, NotFoundException {
     User user = UserUtility.getUser(getThreadLocalRequest());
     return RODAInstance.registerLocalInstance(user, localInstance);
   }


### PR DESCRIPTION
fix #2032:

- [x] Convert `InstanceIdentifierRodaEntityPlugin` plugin to multi-step
- [x] Add the registration step in this process
- [x] Allow synchronization only after execution of the multi-step plugin, using `LocalInstanceIdentifierState`