### PR TITLE
Guest with no permissions can still view list of users in Permissions group on AIP sidebar

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -1767,6 +1767,7 @@ public final class RodaConstants {
   public static final String PERMISSION_METHOD_UPDATE_DESCRIPTIVE_METADATA_FILE = "org.roda.wui.api.controllers.Browser.updateDescriptiveMetadataFile";
   public static final String PERMISSION_METHOD_DELETE_DESCRIPTIVE_METADATA_FILE = "org.roda.wui.api.controllers.Browser.deleteDescriptiveMetadataFile";
   public static final String PERMISSION_METHOD_RETRIEVE_DESCRIPTIVE_METADATA_VERSIONS_BUNDLE = "org.roda.wui.api.controllers.Browser.retrieveDescriptiveMetadataVersionsBundle";
+  public  static final String PERMISSION_METHOD_LIST_USERS =  "org.roda.wui.api.controllers.Browser.findAll(RODAMember)";
 
   public static final String PERMISSION_METHOD_CREATE_USER = "org.roda.wui.api.controllers.UserManagement.createUser";
   public static final String PERMISSION_METHOD_CREATE_GROUP = "org.roda.wui.api.controllers.UserManagement.createGroup";

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/controllers/BrowserHelper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/controllers/BrowserHelper.java
@@ -229,6 +229,11 @@ public class BrowserHelper {
     List<IndexedAIP> ancestors = retrieveAncestors(aip, user, aipAncestorsFieldsToReturn);
     bundle.setAIPAncestors(ancestors);
 
+    if (!UserUtility.hasPermissions(user, RodaConstants.PERMISSION_METHOD_LIST_USERS)) {
+      Permissions p = new Permissions();
+      bundle.getAip().setPermissions(p);
+    }
+
     // set descriptive metadata
     if (UserUtility.hasPermissions(user, RodaConstants.PERMISSION_METHOD_LIST_AIP_DESCRIPTIVE_METADATA)) {
       try {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/slider/InfoSliderHelper.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/slider/InfoSliderHelper.java
@@ -213,11 +213,9 @@ public class InfoSliderHelper {
       values.put(messages.updateProcessIdTitle(), jobIdsList);
     }
 
-    if (PermissionClientUtils.hasPermissions("org.roda.wui.api.controllers.Browser.findAll(RODAMember)")) {
-      if (!bundle.getAip().getPermissions().getUsers().isEmpty()
-              || !bundle.getAip().getPermissions().getGroups().isEmpty()) {
-        values.put(messages.aipPermissionDetails(), createAipPermissionDetailsHTML(bundle));
-      }
+    if (!bundle.getAip().getPermissions().getUsers().equals(new Permissions().getUsers())
+            || !bundle.getAip().getPermissions().getGroups().equals(new Permissions().getGroups())) {
+      values.put(messages.aipPermissionDetails(), createAipPermissionDetailsHTML(bundle));
     }
     populate(infoSliderPanel, values);
   }


### PR DESCRIPTION
Removed the permissions when retrieving the information from the server