### PR TITLE
keeps roda docker image version fix

### DIFF
--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
       - DOC_EXPANSION=none
       - VALIDATOR_URL=none
   roda:
-    image: keeps/roda:latest
+    image: keeps/roda:v5.0.0
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
According to the steps mentioned in roda-community. https://www.roda-community.org/deploys/standalone/

It is not possible to run docker because keeps/roda:latest gives error, which is why I have manually specified its version from docker hub.