### PR TITLE
Local Setup Issue Resolved

### DIFF
--- a/deploys/standalone/docker-compose.yaml
+++ b/deploys/standalone/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
       - DOC_EXPANSION=none
       - VALIDATOR_URL=none
   roda:
-    image: keeps/roda:latest
+    image: ghcr.io/keeps/roda:latest
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION

When setting up the roda locally using the [community guidelines](https://www.roda-community.org/deploys/standalone/)
I encountered the following error:
`keeps/roda:latest not found: manifest unknown: manifest unknown`

I tried to execute 
```
docker pull keeps/roda:latest
```
The above command failed so I did some digging by navigating to the[ link ](ghcr.io/keeps/roda:latest)
After verifying the latest is there I thought of pulling it using the url using following command.
```
docker pull ghcr.io/keeps/roda:latest
```
This command was successful so I became certain that It can be replaced this inside the `docker-compose.yaml` file. I replaced the roda image with it and executed
```
docker compose up -d
```
It was successful.

I think it would be better to use the url like we are doing for other services.