### PR TITLE
Add CSV exports to indexed objects

### DIFF
--- a/roda-core/roda-core/src/main/resources/config/roda-roles.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-roles.properties
@@ -296,6 +296,22 @@ core.roles.org.roda.wui.api.v2.services.IndexService.retrieve(DisposalConfirmati
 
 # Generic export roles
 core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(IndexedAIP) = aip.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(IndexedFile) = representation.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(LogEntry) = log_entry.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(DisposalConfirmation) = disposal_confirmation.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(IndexedReport) = job.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(Job) = job.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(RODAMember) = member.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(Notification) = notification.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(IndexedPreservationAgent) = preservation_metadata.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(IndexedPreservationEvent) = preservation_metadata.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(IndexedRepresentation) = representation.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(RepresentationInformation) = ri.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(IndexedRisk) = risk.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(TransferredResource) = transfer.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(DIPFile) = aip.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(IndexedDIP) = aip.read
+core.roles.org.roda.wui.api.v2.services.IndexService.exportToCSV(RiskIncidence) = incidence.read
 
 # Old roles - deprecated - and soon to be deleted
 core.roles.org.roda.wui.api.controllers.Browser.appraisal = aip.appraisal

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AuditLogController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/AuditLogController.java
@@ -24,18 +24,21 @@ import org.roda.wui.api.v2.exceptions.model.ErrorResponseMessage;
 import org.roda.wui.api.v2.model.GenericOkResponse;
 import org.roda.wui.api.v2.services.AuditLogService;
 import org.roda.wui.api.v2.services.IndexService;
+import org.roda.wui.api.v2.utils.ApiUtils;
 import org.roda.wui.client.services.AuditLogRestService;
 import org.roda.wui.common.ControllerAssistant;
 import org.roda.wui.common.model.RequestContext;
 import org.roda.wui.common.utils.RequestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -49,7 +52,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(path = "/api/v2/audit-logs")
-public class AuditLogController implements AuditLogRestService {
+public class AuditLogController implements AuditLogRestService, Exportable {
   @Autowired
   HttpServletRequest request;
 
@@ -121,5 +124,13 @@ public class AuditLogController implements AuditLogRestService {
     } finally {
       controllerAssistant.registerAction(requestContext, state, RodaConstants.CONTROLLER_FILENAME_PARAM, filename);
     }
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(
+      indexService.exportToCSV(requestContext.getUser(), findRequestString, LogEntry.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPController.java
@@ -53,7 +53,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(path = "/api/v2/dips")
-public class DIPController implements DIPRestService {
+public class DIPController implements DIPRestService, Exportable {
 
   @Autowired
   private HttpServletRequest request;
@@ -170,5 +170,13 @@ public class DIPController implements DIPRestService {
         updateRequest.getItemsToUpdate(), RodaConstants.CONTROLLER_PERMISSIONS_PARAM, updateRequest.getPermissions(),
         RodaConstants.CONTROLLER_DETAILS_PARAM, updateRequest.getDetails());
     }
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(
+      indexService.exportToCSV(requestContext.getUser(), findRequestString, IndexedDIP.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPFileController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPFileController.java
@@ -12,13 +12,16 @@ import org.roda.core.data.v2.index.SuggestRequest;
 import org.roda.core.data.v2.ip.DIPFile;
 import org.roda.core.model.utils.UserUtility;
 import org.roda.wui.api.v2.services.IndexService;
+import org.roda.wui.api.v2.utils.ApiUtils;
 import org.roda.wui.client.services.DIPFileRestService;
 import org.roda.wui.common.model.RequestContext;
 import org.roda.wui.common.utils.RequestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -27,7 +30,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(path = "/api/v2/dip-files")
-public class DIPFileController implements DIPFileRestService {
+public class DIPFileController implements DIPFileRestService, Exportable {
   @Autowired
   HttpServletRequest request;
 
@@ -61,5 +64,13 @@ public class DIPFileController implements DIPFileRestService {
   public List<String> suggest(SuggestRequest suggestRequest) {
     RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
     return indexService.suggest(suggestRequest, DIPFile.class, requestContext);
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils
+      .okResponse(indexService.exportToCSV(requestContext.getUser(), findRequestString, DIPFile.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalConfirmationController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalConfirmationController.java
@@ -56,7 +56,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(path = "/api/v2/disposal/confirmations")
-public class DisposalConfirmationController implements DisposalConfirmationRestService {
+public class DisposalConfirmationController implements DisposalConfirmationRestService, Exportable {
 
   @Autowired
   HttpServletRequest request;
@@ -298,5 +298,13 @@ public class DisposalConfirmationController implements DisposalConfirmationRestS
     } finally {
       controllerAssistant.registerAction(requestContext, state);
     }
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(indexService.exportToCSV(requestContext.getUser(), findRequestString,
+      DisposalConfirmation.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/FilesController.java
@@ -77,7 +77,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping(path = "/api/v2/files")
-public class FilesController implements FileRestService {
+public class FilesController implements FileRestService, Exportable {
   @Autowired
   private HttpServletRequest request;
 
@@ -424,5 +424,13 @@ public class FilesController implements FileRestService {
     } finally {
       controllerAssistant.registerAction(requestContext, LogEntryState.SUCCESS);
     }
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(
+      indexService.exportToCSV(requestContext.getUser(), findRequestString, IndexedFile.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobReportController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobReportController.java
@@ -12,15 +12,17 @@ import org.roda.core.data.v2.index.SuggestRequest;
 import org.roda.core.data.v2.jobs.IndexedReport;
 import org.roda.core.model.utils.UserUtility;
 import org.roda.wui.api.v2.services.IndexService;
+import org.roda.wui.api.v2.utils.ApiUtils;
 import org.roda.wui.client.services.JobReportRestService;
 import org.roda.wui.common.model.RequestContext;
 import org.roda.wui.common.utils.RequestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 
 /**
@@ -28,7 +30,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(path = "/api/v2/job-reports")
-public class JobReportController implements JobReportRestService {
+public class JobReportController implements JobReportRestService, Exportable {
   @Autowired
   private HttpServletRequest request;
 
@@ -61,5 +63,13 @@ public class JobReportController implements JobReportRestService {
   public List<String> suggest(SuggestRequest suggestRequest) {
     RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
     return indexService.suggest(suggestRequest, IndexedReport.class, requestContext);
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(
+      indexService.exportToCSV(requestContext.getUser(), findRequestString, IndexedReport.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobsController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/JobsController.java
@@ -63,7 +63,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping(path = "/api/v2/jobs")
-public class JobsController implements JobsRestService {
+public class JobsController implements JobsRestService, Exportable {
   @Autowired
   private HttpServletRequest request;
 
@@ -328,5 +328,13 @@ public class JobsController implements JobsRestService {
   public List<String> suggest(SuggestRequest suggestRequest) {
     RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
     return indexService.suggest(suggestRequest, Job.class, requestContext);
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils
+      .okResponse(indexService.exportToCSV(requestContext.getUser(), findRequestString, Job.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
@@ -55,6 +55,7 @@ import org.roda.wui.api.v2.exceptions.RESTException;
 import org.roda.wui.api.v2.model.GenericOkResponse;
 import org.roda.wui.api.v2.services.IndexService;
 import org.roda.wui.api.v2.services.MembersService;
+import org.roda.wui.api.v2.utils.ApiUtils;
 import org.roda.wui.api.v2.utils.CommonServicesUtils;
 import org.roda.wui.client.management.recaptcha.RecaptchaException;
 import org.roda.wui.client.services.MembersRestService;
@@ -65,10 +66,12 @@ import org.roda.wui.common.utils.RequestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.ldap.NamingException;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
@@ -81,7 +84,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(path = "/api/v2/members")
-public class MembersController implements MembersRestService {
+public class MembersController implements MembersRestService, Exportable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MembersController.class);
   @Autowired
@@ -774,5 +777,13 @@ public class MembersController implements MembersRestService {
   public List<String> suggest(SuggestRequest suggestRequest) {
     RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
     return indexService.suggest(suggestRequest, RODAMember.class, requestContext);
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(
+      indexService.exportToCSV(requestContext.getUser(), findRequestString, RODAMember.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/NotificationController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/NotificationController.java
@@ -7,40 +7,38 @@ import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.exceptions.NotImplementedException;
 import org.roda.core.data.exceptions.RODAException;
 import org.roda.core.data.utils.JsonUtils;
-import org.roda.core.data.v2.common.Pair;
 import org.roda.core.data.v2.generics.LongResponse;
 import org.roda.core.data.v2.index.CountRequest;
 import org.roda.core.data.v2.index.FindRequest;
 import org.roda.core.data.v2.index.IndexResult;
 import org.roda.core.data.v2.index.SuggestRequest;
-import org.roda.core.data.v2.index.filter.Filter;
-import org.roda.core.data.v2.index.sublist.Sublist;
 import org.roda.core.data.v2.log.LogEntryState;
 import org.roda.core.data.v2.notifications.Notification;
 import org.roda.core.data.v2.notifications.NotificationAcknowledgeRequest;
-import org.roda.core.data.v2.notifications.Notifications;
 import org.roda.core.model.utils.UserUtility;
-import org.roda.wui.api.v1.utils.ApiUtils;
 import org.roda.wui.api.v2.exceptions.RESTException;
 import org.roda.wui.api.v2.model.GenericOkResponse;
 import org.roda.wui.api.v2.services.IndexService;
 import org.roda.wui.api.v2.services.NotificationsService;
+import org.roda.wui.api.v2.utils.ApiUtils;
 import org.roda.wui.client.services.NotificationRestService;
 import org.roda.wui.common.ControllerAssistant;
 import org.roda.wui.common.model.RequestContext;
 import org.roda.wui.common.utils.RequestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping(path = "/api/v2/notifications")
-public class NotificationController implements NotificationRestService {
+public class NotificationController implements NotificationRestService, Exportable {
 
   @Autowired
   private NotificationsService notificationsService;
@@ -109,5 +107,13 @@ public class NotificationController implements NotificationRestService {
   @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
   public List<String> suggest(SuggestRequest suggestRequest) {
     throw new RESTException(new NotImplementedException());
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(
+      indexService.exportToCSV(requestContext.getUser(), findRequestString, Notification.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationAgentController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationAgentController.java
@@ -47,7 +47,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(path = "/api/v2/preservation/agents")
-public class PreservationAgentController implements PreservationAgentRestService {
+public class PreservationAgentController implements PreservationAgentRestService, Exportable {
 
   @Autowired
   HttpServletRequest request;
@@ -117,5 +117,13 @@ public class PreservationAgentController implements PreservationAgentRestService
       controllerAssistant.registerAction(requestContext, id, state, RodaConstants.CONTROLLER_AGENT_ID_PARAM,
         id);
     }
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(indexService.exportToCSV(requestContext.getUser(), findRequestString,
+      IndexedPreservationAgent.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationEventController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/PreservationEventController.java
@@ -58,7 +58,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(path = "/api/v2/preservation/events")
-public class PreservationEventController implements PreservationEventRestService {
+public class PreservationEventController implements PreservationEventRestService, Exportable {
 
   @Autowired
   HttpServletRequest request;
@@ -228,5 +228,13 @@ public class PreservationEventController implements PreservationEventRestService
       controllerAssistant.registerAction(requestContext, id, state,
         RodaConstants.CONTROLLER_INDEX_PRESERVATION_EVENT_ID_PARAM, id);
     }
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(indexService.exportToCSV(requestContext.getUser(), findRequestString,
+      IndexedPreservationEvent.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationController.java
@@ -41,6 +41,7 @@ import org.roda.wui.api.controllers.BrowserHelper;
 import org.roda.wui.api.v2.exceptions.RESTException;
 import org.roda.wui.api.v2.services.IndexService;
 import org.roda.wui.api.v2.services.RepresentationService;
+import org.roda.wui.api.v2.utils.ApiUtils;
 import org.roda.wui.api.v2.utils.CommonServicesUtils;
 import org.roda.wui.client.services.RepresentationRestService;
 import org.roda.wui.common.ControllerAssistant;
@@ -50,9 +51,11 @@ import org.roda.wui.common.utils.RequestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -62,7 +65,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping(path = "/api/v2/representations")
-public class RepresentationController implements RepresentationRestService {
+public class RepresentationController implements RepresentationRestService, Exportable {
   private static final Logger LOGGER = LoggerFactory.getLogger(RepresentationController.class);
   @Autowired
   private HttpServletRequest request;
@@ -385,5 +388,13 @@ public class RepresentationController implements RepresentationRestService {
     } finally {
       controllerAssistant.registerAction(requestContext, LogEntryState.SUCCESS);
     }
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(indexService.exportToCSV(requestContext.getUser(), findRequestString,
+      IndexedRepresentation.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationInformationController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RepresentationInformationController.java
@@ -65,7 +65,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(path = "/api/v2/representation-information")
-public class RepresentationInformationController implements RepresentationInformationRestService {
+public class RepresentationInformationController implements RepresentationInformationRestService, Exportable {
   @Autowired
   HttpServletRequest request;
 
@@ -368,5 +368,13 @@ public class RepresentationInformationController implements RepresentationInform
       controllerAssistant.registerAction(requestContext, id, state, RodaConstants.CONTROLLER_REPRESENTATION_ID_PARAM,
         id);
     }
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(indexService.exportToCSV(requestContext.getUser(), findRequestString,
+      RepresentationInformation.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskController.java
@@ -30,15 +30,18 @@ import org.roda.core.model.utils.UserUtility;
 import org.roda.wui.api.v2.exceptions.RESTException;
 import org.roda.wui.api.v2.services.IndexService;
 import org.roda.wui.api.v2.services.RiskService;
+import org.roda.wui.api.v2.utils.ApiUtils;
 import org.roda.wui.api.v2.utils.CommonServicesUtils;
 import org.roda.wui.client.services.RiskRestService;
 import org.roda.wui.common.ControllerAssistant;
 import org.roda.wui.common.model.RequestContext;
 import org.roda.wui.common.utils.RequestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -47,7 +50,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(path = "/api/v2/risks")
-public class RiskController implements RiskRestService {
+public class RiskController implements RiskRestService, Exportable {
 
   @Autowired
   private HttpServletRequest request;
@@ -331,5 +334,13 @@ public class RiskController implements RiskRestService {
       // register action
       controllerAssistant.registerAction(requestContext, state);
     }
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(
+      indexService.exportToCSV(requestContext.getUser(), findRequestString, IndexedRisk.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskIncidenceController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskIncidenceController.java
@@ -23,15 +23,18 @@ import org.roda.core.model.utils.UserUtility;
 import org.roda.wui.api.v2.exceptions.RESTException;
 import org.roda.wui.api.v2.services.IndexService;
 import org.roda.wui.api.v2.services.RiskIncidenceService;
+import org.roda.wui.api.v2.utils.ApiUtils;
 import org.roda.wui.api.v2.utils.CommonServicesUtils;
 import org.roda.wui.client.services.RiskIncidenceRestService;
 import org.roda.wui.common.ControllerAssistant;
 import org.roda.wui.common.model.RequestContext;
 import org.roda.wui.common.utils.RequestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -40,7 +43,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @RestController
 @RequestMapping(path = "/api/v2/incidences")
-public class RiskIncidenceController implements RiskIncidenceRestService {
+public class RiskIncidenceController implements RiskIncidenceRestService, Exportable {
 
   @Autowired
   private HttpServletRequest request;
@@ -145,5 +148,13 @@ public class RiskIncidenceController implements RiskIncidenceRestService {
       controllerAssistant.registerAction(requestContext, incidence.getId(), state,
         RodaConstants.CONTROLLER_INCIDENCE_PARAM, incidence);
     }
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(
+      indexService.exportToCSV(requestContext.getUser(), findRequestString, RiskIncidence.class, requestContext));
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/TransferredResourceController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/TransferredResourceController.java
@@ -60,7 +60,7 @@ import jakarta.servlet.http.HttpServletRequest;
 @RestController
 @RequestMapping(path = "/api/v2/transfers")
 @Tag(name = TransferredResourceController.SWAGGER_ENDPOINT)
-public class TransferredResourceController implements TransferredResourceRestService {
+public class TransferredResourceController implements TransferredResourceRestService, Exportable {
   public static final String SWAGGER_ENDPOINT = "v2 transfers";
 
   @Autowired
@@ -327,5 +327,13 @@ public class TransferredResourceController implements TransferredResourceRestSer
   public List<String> suggest(SuggestRequest suggestRequest) {
     RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
     return indexService.suggest(suggestRequest, TransferredResource.class, requestContext);
+  }
+
+  @Override
+  public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
+    RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
+    // delegate
+    return ApiUtils.okResponse(
+      indexService.exportToCSV(requestContext.getUser(), findRequestString, TransferredResource.class, requestContext));
   }
 }


### PR DESCRIPTION
- Adds `exportToCSV` methods to the controllers of indexed object types
- Specifies role permission configurations to newly added `exportToCSV` methods.