### PR TITLE
Fix table elements counting

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
@@ -210,8 +210,8 @@ public abstract class AsyncTableCell<T extends IsIndexed> extends FlowPanel
         return AsyncTableCell.this.getData(sublist, sorter, fieldsToReturn).thenApply(tIndexResult -> {
           setResult(tIndexResult);
           if (redirectOnSingleResult && originalFilter.equals(AsyncTableCell.this.getFilter())
-            && getVisibleItems().size() == 1) {
-            HistoryUtils.resolve(getVisibleItems().get(0), true);
+            && tIndexResult.getResults().size() == 1) {
+            HistoryUtils.resolve(tIndexResult.getResults().getFirst(), true);
           }
 
           if (tIndexResult.getResults().isEmpty()) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
@@ -211,7 +211,7 @@ public abstract class AsyncTableCell<T extends IsIndexed> extends FlowPanel
           setResult(tIndexResult);
           if (redirectOnSingleResult && originalFilter.equals(AsyncTableCell.this.getFilter())
             && tIndexResult.getResults().size() == 1) {
-            HistoryUtils.resolve(tIndexResult.getResults().getFirst(), true);
+            HistoryUtils.resolve(tIndexResult.getResults().get(0), true);
           }
 
           if (tIndexResult.getResults().isEmpty()) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCell.java
@@ -214,7 +214,7 @@ public abstract class AsyncTableCell<T extends IsIndexed> extends FlowPanel
             HistoryUtils.resolve(getVisibleItems().get(0), true);
           }
 
-          if (getVisibleItems().isEmpty()) {
+          if (tIndexResult.getResults().isEmpty()) {
             AsyncTableCell.this.addStyleName("table-empty");
           } else {
             AsyncTableCell.this.removeStyleName("table-empty");


### PR DESCRIPTION
`AsyncTableCell` was getting incorrect results when counting elements by using `getVisibleItems`. Using the results of `getData` instead fixes the issues, which are:
- Occupied tables being styled as if they were empty
- Tables with one element not automatically redirecting to the element's panel