### PR TITLE
Renamed applyDisposalRules's includeManually query parameter

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/rules/ApplyDisposalRulesPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/disposal/rules/ApplyDisposalRulesPlugin.java
@@ -57,7 +57,7 @@ public class ApplyDisposalRulesPlugin extends AbstractPlugin<AIP> {
       PluginParameter
         .getBuilder(RodaConstants.PLUGIN_PARAMS_DISPOSAL_SCHEDULE_OVERWRITE_MANUAL, "Override disposal schedule",
           PluginParameter.PluginParameterType.BOOLEAN)
-        .withDefaultValue("false").withDescription("Overrides disposal schedules manually associated").build());
+        .withDefaultValue("false").withDescription("Overrides manually associated disposal schedules.").build());
   }
 
   private boolean overrideManualAssociations = false;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalRuleController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DisposalRuleController.java
@@ -169,7 +169,7 @@ public class DisposalRuleController implements DisposalRuleRestService {
   }
 
   @Override
-  public Job applyDisposalRules(boolean includeManually) {
+  public Job applyDisposalRules(boolean overrideManualAssociations) {
     ControllerAssistant controllerAssistant = new ControllerAssistant() {};
     RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
     LogEntryState state = LogEntryState.SUCCESS;
@@ -178,7 +178,7 @@ public class DisposalRuleController implements DisposalRuleRestService {
       // check user permissions
       controllerAssistant.checkRoles(requestContext.getUser());
       // delegate
-      return disposalRuleService.applyDisposalRules(requestContext.getUser(), includeManually);
+      return disposalRuleService.applyDisposalRules(requestContext.getUser(), overrideManualAssociations);
     } catch (AuthorizationDeniedException e) {
       state = LogEntryState.UNAUTHORIZED;
       throw new RESTException(e);
@@ -188,7 +188,7 @@ public class DisposalRuleController implements DisposalRuleRestService {
     } finally {
       // register action
       controllerAssistant.registerAction(requestContext, state,
-        RodaConstants.CONTROLLER_DISPOSAL_RULE_OVERRIDE_MANUAL_PARAM, includeManually);
+        RodaConstants.CONTROLLER_DISPOSAL_RULE_OVERRIDE_MANUAL_PARAM, overrideManualAssociations);
     }
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DisposalRuleService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DisposalRuleService.java
@@ -61,11 +61,11 @@ public class DisposalRuleService {
     RodaCoreFactory.getModelService().deleteDisposalRule(id, user.getName());
   }
 
-  public Job applyDisposalRules(User user, boolean applyToManuallyInclusive)
+  public Job applyDisposalRules(User user, boolean overrideManualAssociations)
     throws NotFoundException, AuthorizationDeniedException, GenericException, RequestNotValidException {
     Map<String, String> pluginParameters = new HashMap<>();
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_DISPOSAL_SCHEDULE_OVERWRITE_MANUAL,
-      Boolean.toString(applyToManuallyInclusive));
+      Boolean.toString(overrideManualAssociations));
 
     return CommonServicesUtils.createAndExecuteInternalJob("Apply disposal rules to repository",
       new SelectedItemsFilter<>(new Filter(new SimpleFilterParameter(RodaConstants.AIP_STATE, AIPState.ACTIVE.name())),

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalRuleActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/DisposalRuleActions.java
@@ -38,9 +38,9 @@ public class DisposalRuleActions {
           if (result) {
             DisposalDialogs.showApplyRules(messages.applyDisposalRulesDialogTitle(), new NoAsyncCallback<Boolean>() {
               @Override
-              public void onSuccess(Boolean applyToManuallyInclusive) {
+              public void onSuccess(Boolean overrideManualAssociations) {
                 Services services = new Services("Apply disposal rules", "job");
-                services.disposalRuleResource(s -> s.applyDisposalRules(applyToManuallyInclusive))
+                services.disposalRuleResource(s -> s.applyDisposalRules(overrideManualAssociations))
                   .whenComplete((job, throwable) -> {
                     if (throwable != null) {
                       AsyncCallbackUtils.defaultFailureTreatment(throwable);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DisposalRuleRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DisposalRuleRestService.java
@@ -62,9 +62,9 @@ public interface DisposalRuleRestService extends DirectRestService {
     @Parameter(description = "The ID of the disposal rule to delete.", required = true) @PathVariable(name = "id") String id);
 
   @RequestMapping(method = RequestMethod.POST, path = "/apply", produces = MediaType.APPLICATION_JSON_VALUE)
-  @Operation(summary = "Apply disposal rule to repository", description = "Applies the set of rules defined to the all repository. AIPs which their disposal schedule was manually associated may it can be override using the query parameter.", responses = {
+  @Operation(summary = "Apply disposal rule to repository", description = "Applies the set of rules defined to the all repository. An AIP's manually associated disposal schedules may be overwritten by specifying the appropriate query parameter.", responses = {
     @ApiResponse(responseCode = "200", description = "Job created", content = @Content(schema = @Schema(implementation = Job.class))),
     @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
   Job applyDisposalRules(
-    @Parameter(description = "If true disposal schedules that were manually associated to an intellectual entity may be associated to a different disposal schedule", content = @Content(schema = @Schema(implementation = boolean.class, defaultValue = "false"))) @RequestParam(name = "includeManually", required = false, defaultValue = "false") boolean includeManually);
+    @Parameter(description = "If true, overrides manually associated disposal schedules.", content = @Content(schema = @Schema(implementation = boolean.class, defaultValue = "false"))) @RequestParam(name = "overrideManualAssociations", required = false, defaultValue = "false") boolean overrideManualAssociations);
 }


### PR DESCRIPTION
Renamed `DisposalRuleRestService.applyDisposalRules`'s `includeManually` parameter to `overrideManualAssociations`. Changed documentation related to this method to more clearly describe its function.