### PR TITLE
Disposal Hold lift details and prompts

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/disposalhold/DisassociateDisposalHoldRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/disposalhold/DisassociateDisposalHoldRequest.java
@@ -1,0 +1,48 @@
+package org.roda.core.data.v2.ip.disposalhold;
+
+/**
+ * @author Miguel Guimarães <mguimaraes@keep.pt>
+ */
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import org.roda.core.data.v2.generics.select.SelectedItemsRequest;
+
+public class DisassociateDisposalHoldRequest implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = 1324253414733503493L;
+
+  private SelectedItemsRequest selectedItems;
+  private String details;
+  private boolean clear;
+
+  public DisassociateDisposalHoldRequest() {
+    // empty constructor
+  }
+
+  public SelectedItemsRequest getSelectedItems() {
+    return selectedItems;
+  }
+
+  public void setSelectedItems(SelectedItemsRequest selectedItems) {
+    this.selectedItems = selectedItems;
+  }
+
+  public String getDetails() {
+    return details;
+  }
+
+  public void setDetails(String details) {
+    this.details = details;
+  }
+
+  public boolean getClear() {
+    return clear;
+  }
+
+  public void setClear(boolean clear) {
+    this.clear = clear;
+  }
+}

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/disposalhold/LiftDisposalHoldRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/disposalhold/LiftDisposalHoldRequest.java
@@ -1,0 +1,39 @@
+package org.roda.core.data.v2.ip.disposalhold;
+
+/**
+ * @author Miguel Guimarães <mguimaraes@keep.pt>
+ */
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import org.roda.core.data.v2.generics.select.SelectedItemsRequest;
+
+public class LiftDisposalHoldRequest implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = -6983980156805237858L;
+
+  private SelectedItemsRequest selectedItems;
+  private String details;
+
+  public LiftDisposalHoldRequest() {
+    // empty constructor
+  }
+
+  public SelectedItemsRequest getSelectedItems() {
+    return selectedItems;
+  }
+
+  public void setSelectedItems(SelectedItemsRequest selectedItems) {
+    this.selectedItems = selectedItems;
+  }
+
+  public String getDetails() {
+    return details;
+  }
+
+  public void setDetails(String details) {
+    this.details = details;
+  }
+}

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/disposalhold/UpdateDisposalHoldRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/disposalhold/UpdateDisposalHoldRequest.java
@@ -1,0 +1,39 @@
+package org.roda.core.data.v2.ip.disposalhold;
+
+/**
+ * @author Miguel Guimarães <mguimaraes@keep.pt>
+ */
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import org.roda.core.data.v2.disposal.hold.DisposalHold;
+
+public class UpdateDisposalHoldRequest implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = 3125581525913041977L;
+
+  private DisposalHold disposalHold;
+  private String details;
+
+  public UpdateDisposalHoldRequest() {
+    // empty constructor
+  }
+
+  public DisposalHold getDisposalHold() {
+    return disposalHold;
+  }
+
+  public void setDisposalHold(DisposalHold disposalHold) {
+    this.disposalHold = disposalHold;
+  }
+
+  public String getDetails() {
+    return details;
+  }
+
+  public void setDetails(String details) {
+    this.details = details;
+  }
+}

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/ModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/ModelService.java
@@ -3747,16 +3747,17 @@ public class ModelService extends ModelObservable {
   public DisposalHold updateDisposalHoldFirstUseDate(DisposalHold disposalHold, String updatedBy)
     throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, IllegalOperationException,
     GenericException {
-    return updateDisposalHold(disposalHold, updatedBy, true);
+    return updateDisposalHold(disposalHold, updatedBy, true, null);
   }
 
-  public DisposalHold updateDisposalHold(DisposalHold disposalHold, String updatedBy)
+  public DisposalHold updateDisposalHold(DisposalHold disposalHold, String updatedBy, String details)
     throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, IllegalOperationException,
     GenericException {
-    return updateDisposalHold(disposalHold, updatedBy, false);
+    return updateDisposalHold(disposalHold, updatedBy, false, details);
   }
 
-  public DisposalHold updateDisposalHold(DisposalHold disposalHold, String updatedBy, boolean updateFirstUseDate)
+  public DisposalHold updateDisposalHold(DisposalHold disposalHold, String updatedBy, boolean updateFirstUseDate,
+    String details)
     throws RequestNotValidException, NotFoundException, GenericException, AuthorizationDeniedException,
     IllegalOperationException {
     RodaCoreFactory.checkIfWriteIsAllowedAndIfFalseThrowException(nodeType);
@@ -3786,6 +3787,9 @@ public class ModelService extends ModelObservable {
     StoragePath disposalHoldPath = ModelUtils.getDisposalHoldStoragePath(currentDisposalHold.getId());
 
     storage.updateBinaryContent(disposalHoldPath, new StringContentPayload(disposalHoldAsJson), false, true);
+
+    createRepositoryEvent(PreservationEventType.UPDATE, "Update disposal hold", PluginState.SUCCESS, "", details, "",
+      true);
 
     return currentDisposalHold;
   }

--- a/roda-core/roda-core/src/main/resources/config/roda-roles.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-roles.properties
@@ -129,7 +129,7 @@ core.roles.org.roda.wui.api.v2.controller.DisposalHoldController.createDisposalH
 core.roles.org.roda.wui.api.v2.controller.DisposalHoldController.retrieveDisposalHold = disposal_hold.read
 core.roles.org.roda.wui.api.v2.controller.DisposalRuleController.updateDisposalRule = disposal_hold.manage
 core.roles.org.roda.wui.api.v2.controller.DisposalHoldController.applyDisposalHold = disposal_hold.apply
-core.roles.org.roda.wui.api.v2.controller.DisposalHoldController.liftDisposalHoldBySelectedItems = disposal_hold.apply
+core.roles.org.roda.wui.api.v2.controller.DisposalHoldController.liftDisposalHold=disposal_hold.apply
 core.roles.org.roda.wui.api.v2.controller.DisposalHoldController.disassociateDisposalHold = disposal_hold.apply
 core.roles.org.roda.wui.api.v2.controller.DisposalHoldController.listTransitiveHolds = disposal_hold.read
 core.roles.org.roda.wui.api.v2.controller.DisposalHoldController.listDisposalHoldsAssociation = disposal_hold.read

--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -2149,6 +2149,10 @@ public interface ClientMessages extends Messages {
 
   String clearDisposalHoldDialogMessage(@PluralCount int size);
 
+  String liftDisposalHoldDialogTitle();
+
+  String liftDisposalHoldDialogMessage(@PluralCount int size);
+
   String disassociateDisposalHoldDialogTitle();
 
   String disassociateDisposalHoldDialogMessage(@PluralCount int size);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/hold/EditDisposalHold.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/hold/EditDisposalHold.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.roda.core.data.v2.disposal.hold.DisposalHold;
 import org.roda.core.data.v2.disposal.hold.DisposalHoldState;
+import org.roda.core.data.v2.ip.disposalhold.UpdateDisposalHoldRequest;
 import org.roda.wui.client.common.UserLogin;
 import org.roda.wui.client.common.utils.AsyncCallbackUtils;
 import org.roda.wui.client.common.utils.JavascriptUtils;
@@ -118,8 +119,10 @@ public class EditDisposalHold extends Composite {
       disposalHold.setMandate(disposalHoldUpdated.getMandate());
       disposalHold.setDescription(disposalHoldUpdated.getDescription());
       disposalHold.setScopeNotes(disposalHoldUpdated.getScopeNotes());
+      UpdateDisposalHoldRequest request = new UpdateDisposalHoldRequest();
+      request.setDisposalHold(disposalHold);
       Services services = new Services("Update disposal hold", "update");
-      services.disposalHoldResource(s -> s.updateDisposalHold(disposalHold)).whenComplete((hold, throwable) -> {
+      services.disposalHoldResource(s -> s.updateDisposalHold(request)).whenComplete((hold, throwable) -> {
         if (throwable != null) {
           AsyncCallbackUtils.defaultFailureTreatment(throwable);
         } else {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DisposalHoldRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/DisposalHoldRestService.java
@@ -6,6 +6,8 @@ import org.roda.core.data.v2.disposal.hold.DisposalHolds;
 import org.roda.core.data.v2.disposal.metadata.DisposalHoldsAIPMetadata;
 import org.roda.core.data.v2.disposal.metadata.DisposalTransitiveHoldsAIPMetadata;
 import org.roda.core.data.v2.generics.select.SelectedItemsRequest;
+import org.roda.core.data.v2.ip.disposalhold.DisassociateDisposalHoldRequest;
+import org.roda.core.data.v2.ip.disposalhold.UpdateDisposalHoldRequest;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.wui.api.v2.exceptions.model.ErrorResponseMessage;
 import org.springframework.http.HttpStatus;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -22,7 +25,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
  * @author Miguel Guimaraes <mguimarães@keep.pt>
@@ -40,12 +42,12 @@ public interface DisposalHoldRestService extends DirectRestService {
   DisposalHolds listDisposalHolds();
 
   @RequestMapping(method = RequestMethod.PUT, path = "", produces = MediaType.APPLICATION_JSON_VALUE)
-  @Operation(summary = "Update disposal hold", description = "Update existing disposal hold", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = DisposalHold.class))), responses = {
+  @Operation(summary = "Update disposal hold", description = "Update existing disposal hold", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UpdateDisposalHoldRequest.class))), responses = {
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = DisposalHold.class))),
     @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class))),
     @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class))),
     @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
-  DisposalHold updateDisposalHold(DisposalHold hold);
+  DisposalHold updateDisposalHold(UpdateDisposalHoldRequest updateDisposalHoldRequest);
 
   @RequestMapping(method = RequestMethod.POST, path = "", produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.CREATED)
@@ -72,15 +74,6 @@ public interface DisposalHoldRestService extends DirectRestService {
     @Parameter(description = "Disposal hold id", required = true) @PathVariable(name = "id") String disposalHoldId,
     @Parameter(name = "override", description = "Lift all disposal holds associated and apply the selected disposal hold") @RequestParam(name = "override", required = false, defaultValue = "false") boolean override);
 
-  @RequestMapping(method = RequestMethod.POST, path = "/{id}/lift", produces = MediaType.APPLICATION_JSON_VALUE)
-  @Operation(summary = "Lift disposal holds from selected AIPs", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = SelectedItemsRequest.class))), responses = {
-    @ApiResponse(responseCode = "200", description = "Job created", content = @Content(schema = @Schema(implementation = Job.class))),
-    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class))),
-    @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class))),})
-  Job liftDisposalHoldBySelectedItems(
-    @Parameter(description = "Selected AIPs", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) SelectedItemsRequest selectedItems,
-    @Parameter(description = "disposal hold id", required = true) @PathVariable(name = "id") String disposalHoldId);
-
   @RequestMapping(method = RequestMethod.PUT, path = "/{id}/lift", produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(summary = "Lift specific disposal hold", responses = {
     @ApiResponse(responseCode = "200", description = "Job created", content = @Content(schema = @Schema(implementation = DisposalHold.class))),
@@ -88,17 +81,16 @@ public interface DisposalHoldRestService extends DirectRestService {
     @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class))),
     @ApiResponse(responseCode = "404", description = "Disposal hold not found", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
   DisposalHold liftDisposalHold(
-    @Parameter(description = "Disposal hold id", required = true) @PathVariable(name = "id") String id);
+    @Parameter(description = "Disposal hold id", required = true) @PathVariable(name = "id") String id,
+    @Parameter(description = "Outcome details", required = true) @RequestParam(name = "details", required = false, defaultValue = "") String details);
 
-  @RequestMapping(method = RequestMethod.POST, path = "/disassociate", produces = MediaType.APPLICATION_JSON_VALUE)
-  @Operation(summary = "Disassociate disposal hold from selected AIPs", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = SelectedItemsRequest.class))), responses = {
+  @RequestMapping(method = RequestMethod.POST, path = "/{id}/disassociate", produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(summary = "Disassociate disposal hold from selected AIPs", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = DisassociateDisposalHoldRequest.class))), responses = {
     @ApiResponse(responseCode = "200", description = "Job created", content = @Content(schema = @Schema(implementation = Job.class))),
     @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class))),
     @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
-  Job disassociateDisposalHold(
-    @Parameter(description = "Selected AIPs", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) SelectedItemsRequest selectedItems,
-    @Parameter(description = "Disposal hold id") @PathVariable(name = "id", required = false) String disposalHoldId,
-    @Parameter(name = "clear", description = "Disassociate all disposal holds associated to AIP") @RequestParam(name = "clear", required = false, defaultValue = "false") boolean clear);
+  Job disassociateDisposalHold(DisassociateDisposalHoldRequest request,
+    @Parameter(description = "Disposal hold id", required = false) @PathVariable(name = "id") String disposalHoldId);
 
   @RequestMapping(method = RequestMethod.GET, path = "/transitive/{aip-id}", produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(summary = "List transitive holds", responses = {

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1516,6 +1516,9 @@ overrideDisposalHoldButton:Override disposal hold
 clearDisposalHoldDialogTitle:Clear disposal holds
 clearDisposalHoldDialogMessage[one]:Are you sure you want to disassociate all disposal holds from the selected item?
 clearDisposalHoldDialogMessage:Are you sure you want to disassociate all disposal holds from the selected {0, number} items?
+liftDisposalHoldDialogTitle:Lift disposal hold
+liftDisposalHoldDialogMessage[\=1]:Are you sure you want to lift the disposal hold?
+liftDisposalHoldDialogMessage:Are you sure you want to lift the {0, number} selected disposal holds?
 disassociateDisposalHoldDialogTitle:Disassociate disposal hold
 disassociateDisposalHoldDialogMessage[one]:Are you sure you want to disassociate the disposal hold from the selected item?
 disassociateDisposalHoldDialogMessage:Are you sure you want to disassociate the disposal hold from the selected {0, number} items?


### PR DESCRIPTION
- Adds outcome detailing prompts to lifting/dissociating prompts for disposal holds
- Adds preservation event generation for Disposal Hold updating via `ModelService`
- Replaces usage of the `liftDisposalHoldBySelectedItems` API method with `dissociateDisposalHold`