### PR TITLE
EditFileFormatPlugin

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -1710,7 +1710,7 @@ public final class RodaConstants {
   public static final String SIEGFRIED_PAYLOAD_MATCH_FORMAT_VERSION = "version";
 
   /* Preservation agents fields regex */
-  public static final String REGEX_PUID = "(?:x-)?[a-z0-9]+\\/[a-z0-9]+";
+  public static final String REGEX_PUID = "(?:fmt|x-fmt)\\/[a-z0-9]+";
   public static final String REGEX_MIME = "\\w+\\/[-+.\\w]+";
 
   /* Preservation agents fields */

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -1341,6 +1341,7 @@ public final class RodaConstants {
   public static final String PLUGIN_PARAMS_EVENT_DESCRIPTION = "parameter.event_description";
   public static final String PLUGIN_PARAMS_DELETE_OLDER_THAN_X_DAYS = "parameter.delete_older_than_x_days";
   public static final String PLUGIN_PARAMS_SIP_UPDATE_INFORMATION = "parameter.sip_update_information";
+  public static final String PLUGIN_PARAMS_SIEGFRIED_OVERWRITE_MANUAL = "parameter.siegfried_overwrite_manual";
   public static final String PLUGIN_PARAMS_REPRESENTATION_TYPE = "parameter.representation_type";
   public static final String PLUGIN_PARAMS_OUTCOMEOBJECTID_TO_SOURCEOBJECTID_MAP = "parameter.outcomeobjectid_to_sourceobjectid_map";
   public static final String PLUGIN_PARAMS_NEW_TYPE = "parameter.new_type";
@@ -1413,6 +1414,15 @@ public final class RodaConstants {
   public static final String PLUGIN_PARAMS_DO_BUILD_SYNC_MANIFEST_PLUGIN = "parameter.do_build_sync_manifest";
   public static final String PLUGIN_PARAMS_DO_SEND_SYNC_BUNDLE_PLUGIN = "parameter.do_send_sync_bundle";
   public static final String PLUGIN_PARAMS_DO_REQUEST_SYNC_BUNDLE_PLUGIN = "parameter.do_request_sync_bundle";
+
+  // Edit File Format Plugin Parameters
+
+  public static final String PLUGIN_PARAMS_EXTENSION = "parameter.extension";
+  public static final String PLUGIN_PARAMS_MIMETYPE = "parameter.mime_type";
+  public static final String PLUGIN_PARAMS_FORMAT = "parameter.format";
+  public static final String PLUGIN_PARAMS_FORMAT_VERSION = "parameter.format_version";
+  public static final String PLUGIN_PARAMS_PRONOM = "parameter.pronom";
+
   public static final String PLUGIN_CATEGORY_CONVERSION = "conversion";
   public static final String PLUGIN_CATEGORY_CHARACTERIZATION = "characterization";
   public static final String PLUGIN_CATEGORY_RISK_MANAGEMENT = "risk_management";
@@ -1690,6 +1700,19 @@ public final class RodaConstants {
   /* Disposal Confirmation */
   public static final String DISPOSAL_CONFIRMATION_ID = "id";
 
+  /* Siegfriend payload fields */
+  public static final String SIEGFRIED_PAYLOAD_MATCHES = "matches";
+  public static final String SIEGFRIED_PAYLOAD_MATCH_NS = "ns";
+  public static final String SIEGFRIED_PAYLOAD_MATCH_NS_PRONOM = "pronom";
+  public static final String SIEGFRIED_PAYLOAD_MATCH_MIMETYPE = "mime";
+  public static final String SIEGFRIED_PAYLOAD_MATCH_ID = "id";
+  public static final String SIEGFRIED_PAYLOAD_MATCH_FORMAT_DESIGNATION = "format";
+  public static final String SIEGFRIED_PAYLOAD_MATCH_FORMAT_VERSION = "version";
+
+  /* Preservation agents fields regex */
+  public static final String REGEX_PUID = "(?:x-)?[a-z0-9]+\\/[a-z0-9]+";
+  public static final String REGEX_MIME = "\\w+\\/[-+.\\w]+";
+
   /* Preservation agents fields */
   public static final String PRESERVATION_AGENT_ID = "id";
   public static final String PRESERVATION_AGENT_NAME = "name";
@@ -1719,6 +1742,8 @@ public final class RodaConstants {
   public static final String PRESERVATION_LEVEL_BITLEVEL = "bitlevel";
   public static final String PRESERVATION_REGISTRY_PRONOM = "pronom";
   public static final String PRESERVATION_REGISTRY_MIME = "mime";
+
+  public static final String PRESERVATION_FORMAT_NOTE_MANUAL = "manual";
 
   public static final String PREMIS_RELATIONSHIP_TYPE_STRUCTURAL = "structural";
   public static final String PREMIS_RELATIONSHIP_SUBTYPE_HASPART = "hasPart";

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/PremisV3Utils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/PremisV3Utils.java
@@ -295,14 +295,6 @@ public final class PremisV3Utils {
           PremisSkeletonPluginUtils.createPremisSkeletonOnRepresentation(model, aipId, representationId, algorithms,
             username);
         } else {
-          // File file;
-          // if (shallow) {
-          // file = model.retrieveFileInsideManifest(aipId, representationId,
-          // fileDirectoryPath, fileId);
-          // } else {
-          // file = model.retrieveFile(aipId, representationId, fileDirectoryPath,
-          // fileId);
-          // }
           File file = model.retrieveFile(aipId, representationId, fileDirectoryPath, fileId);
           PremisSkeletonPluginUtils.createPremisSkeletonOnFile(model, file, algorithms, username);
         }

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/PremisV3Utils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/PremisV3Utils.java
@@ -172,7 +172,13 @@ public final class PremisV3Utils {
   }
 
   public static void updateFileFormat(gov.loc.premis.v3.File file, String formatDesignationName,
-                                      String formatDesignationVersion, String pronom, String mimeType) {
+    String formatDesignationVersion, String pronom, String mimeType, List<String> notes) {
+
+    if (notes != null) {
+      List<String> fn = getFormatNote(file);
+      fn.clear();
+      fn.addAll(notes);
+    }
 
     if (StringUtils.isNotBlank(formatDesignationName)) {
       FormatDesignationComplexType fdct = getFormatDesignation(file);
@@ -193,6 +199,11 @@ public final class PremisV3Utils {
       frct.setFormatRegistryKey(getStringPlusAuthority(mimeType));
     }
 
+  }
+
+  public static void updateFileFormat(gov.loc.premis.v3.File file, String formatDesignationName,
+    String formatDesignationVersion, String pronom, String mimeType) {
+    updateFileFormat(file, formatDesignationName, formatDesignationVersion, pronom, mimeType, null);
   }
 
   public static void updateTechnicalMetadata(gov.loc.premis.v3.File file, TechnicalMetadata technicalMetadata)
@@ -271,6 +282,75 @@ public final class PremisV3Utils {
     occt.getObjectCharacteristicsExtension().add(extensionComplexType);
     f.getObjectCharacteristics().add(occt);
     return extensionComplexType;
+  }
+
+  public static boolean formatWasManuallyModified(ModelService model, String aipId, String representationId,
+    List<String> fileDirectoryPath, String fileId, String username) {
+    Binary premisBin = null;
+
+    try {
+      try {
+        premisBin = model.retrievePreservationFile(aipId, representationId, fileDirectoryPath, fileId);
+      } catch (NotFoundException e) {
+        LOGGER.debug("PREMIS object skeleton does not exist yet. Creating PREMIS object!");
+        List<String> algorithms = RodaCoreFactory.getFixityAlgorithms();
+
+        if (fileId == null) {
+          PremisSkeletonPluginUtils.createPremisSkeletonOnRepresentation(model, aipId, representationId, algorithms,
+            username);
+        } else {
+          // File file;
+          // if (shallow) {
+          // file = model.retrieveFileInsideManifest(aipId, representationId,
+          // fileDirectoryPath, fileId);
+          // } else {
+          // file = model.retrieveFile(aipId, representationId, fileDirectoryPath,
+          // fileId);
+          // }
+          File file = model.retrieveFile(aipId, representationId, fileDirectoryPath, fileId);
+          PremisSkeletonPluginUtils.createPremisSkeletonOnFile(model, file, algorithms, username);
+        }
+
+        premisBin = model.retrievePreservationFile(aipId, representationId, fileDirectoryPath, fileId);
+        LOGGER.debug("PREMIS object skeleton created");
+      }
+      gov.loc.premis.v3.File premisFile = binaryToFile(premisBin.getContent(), false);
+      return getFormatNote(premisFile).contains(RodaConstants.PRESERVATION_FORMAT_NOTE_MANUAL);
+    } catch (RODAException | IOException e) {
+      LOGGER.error("PREMIS could not be checked due to an error", e);
+    }
+    return false;
+  }
+
+  public static List<String> getFormatNote(gov.loc.premis.v3.File file) {
+    ObjectCharacteristicsComplexType objectCharacteristics;
+    List<String> formatNote = null;
+    if (file.getObjectIdentifier() != null && !file.getObjectIdentifier().isEmpty()) {
+      objectCharacteristics = file.getObjectCharacteristics().get(0);
+    } else {
+      objectCharacteristics = FACTORY.createObjectCharacteristicsComplexType();
+      file.getObjectCharacteristics().add(objectCharacteristics);
+    }
+
+    if (objectCharacteristics.getFormat() != null && !objectCharacteristics.getFormat().isEmpty()) {
+      for (FormatComplexType format : objectCharacteristics.getFormat()) {
+        if (format.getFormatNote() != null) {
+          formatNote = format.getFormatNote();
+          break;
+        }
+      }
+
+      if (formatNote == null) {
+        FormatComplexType formatComplexType = FACTORY.createFormatComplexType();
+        formatNote = formatComplexType.getFormatNote();
+        objectCharacteristics.getFormat().add(formatComplexType);
+      }
+    } else {
+      FormatComplexType formatComplexType = FACTORY.createFormatComplexType();
+      formatNote = formatComplexType.getFormatNote();
+      objectCharacteristics.getFormat().add(formatComplexType);
+    }
+    return formatNote;
   }
 
   public static FormatRegistryComplexType getFormatRegistry(gov.loc.premis.v3.File file, String registryName) {
@@ -978,8 +1058,8 @@ public final class PremisV3Utils {
   }
 
   public static void updateFormatPreservationMetadata(ModelService model, String aipId, String representationId,
-                                                      List<String> fileDirectoryPath, String fileId, String format, String version, String pronom, String mime,
-                                                      String username, boolean notify) {
+    List<String> fileDirectoryPath, String fileId, String format, String version, String pronom, String mime,
+    List<String> notes, String username, boolean notify) {
     Binary premisBin;
 
     try {
@@ -991,7 +1071,7 @@ public final class PremisV3Utils {
 
         if (fileId == null) {
           PremisSkeletonPluginUtils.createPremisSkeletonOnRepresentation(model, aipId, representationId, algorithms,
-              username);
+            username);
         } else {
           // File file;
           // if (shallow) {
@@ -1010,14 +1090,14 @@ public final class PremisV3Utils {
       }
 
       gov.loc.premis.v3.File premisFile = binaryToFile(premisBin.getContent(), false);
-      PremisV3Utils.updateFileFormat(premisFile, format, version, pronom, mime);
+      PremisV3Utils.updateFileFormat(premisFile, format, version, pronom, mime, notes);
 
       PreservationMetadataType type = PreservationMetadataType.FILE;
       String id = IdUtils.getPreservationFileId(fileId, RODAInstanceUtils.getLocalInstanceIdentifier());
 
       ContentPayload premisFilePayload = fileToBinary(premisFile);
       model.updatePreservationMetadata(id, type, aipId, representationId, fileDirectoryPath, fileId, premisFilePayload,
-          username, notify);
+        username, notify);
     } catch (RODAException | IOException e) {
       LOGGER.error("PREMIS will not be updated due to an error", e);
     }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/EditFileFormatPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/EditFileFormatPlugin.java
@@ -1,0 +1,317 @@
+package org.roda.core.plugins.base.preservation;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+import org.roda.core.common.PremisV3Utils;
+import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.exceptions.AlreadyExistsException;
+import org.roda.core.data.exceptions.AuthorizationDeniedException;
+import org.roda.core.data.exceptions.GenericException;
+import org.roda.core.data.exceptions.InvalidParameterException;
+import org.roda.core.data.exceptions.NotFoundException;
+import org.roda.core.data.exceptions.RequestNotValidException;
+import org.roda.core.data.v2.LiteOptionalWithCause;
+import org.roda.core.data.v2.ip.File;
+import org.roda.core.data.v2.ip.StoragePath;
+import org.roda.core.data.v2.ip.metadata.LinkingIdentifier;
+import org.roda.core.data.v2.jobs.Job;
+import org.roda.core.data.v2.jobs.PluginParameter;
+import org.roda.core.data.v2.jobs.PluginState;
+import org.roda.core.data.v2.jobs.PluginType;
+import org.roda.core.data.v2.jobs.Report;
+import org.roda.core.data.v2.validation.ValidationException;
+import org.roda.core.index.IndexService;
+import org.roda.core.model.ModelService;
+import org.roda.core.model.utils.ModelUtils;
+import org.roda.core.plugins.AbstractPlugin;
+import org.roda.core.plugins.Plugin;
+import org.roda.core.plugins.PluginException;
+import org.roda.core.plugins.PluginHelper;
+import org.roda.core.plugins.RODAObjectsProcessingLogic;
+import org.roda.core.plugins.base.characterization.SiegfriedPlugin;
+import org.roda.core.plugins.orchestrate.JobPluginInfo;
+import org.roda.core.storage.ContentPayload;
+import org.roda.core.storage.DirectResourceAccess;
+import org.roda.core.storage.StorageService;
+import org.roda.core.storage.StringContentPayload;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * @author Alexandre Flores <aflores@keep.pt>
+ */
+public class EditFileFormatPlugin extends AbstractPlugin<File> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(EditFileFormatPlugin.class);
+  private static Map<String, PluginParameter> pluginParameters = new HashMap<>();
+
+  static {
+    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_MIMETYPE,
+      PluginParameter
+        .getBuilder(RodaConstants.PLUGIN_PARAMS_MIMETYPE, "Mimetype", PluginParameter.PluginParameterType.STRING)
+        .withDescription("The Mimetype to set for all selected files.").build());
+    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_FORMAT,
+      PluginParameter
+        .getBuilder(RodaConstants.PLUGIN_PARAMS_FORMAT, "Format", PluginParameter.PluginParameterType.STRING)
+        .withDescription("The full format descriptor to set for all selected files.").build());
+    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_FORMAT_VERSION,
+      PluginParameter
+        .getBuilder(RodaConstants.PLUGIN_PARAMS_FORMAT_VERSION, "Format version",
+          PluginParameter.PluginParameterType.STRING)
+        .withDescription("The version for the format descriptor to set for all selected files.").build());
+    pluginParameters.put(RodaConstants.PLUGIN_PARAMS_PRONOM,
+      PluginParameter
+        .getBuilder(RodaConstants.PLUGIN_PARAMS_PRONOM, "PRONOM", PluginParameter.PluginParameterType.STRING)
+        .withDescription("The PRONOM identifier to set for all selected files.").build());
+  }
+
+  private String mimetype;
+  private String format;
+  private String formatVersion;
+  private String pronom;
+
+  public static String getStaticName() {
+    return "Edit File Format";
+  }
+
+  public static String getStaticDescription() {
+    return "Overwrites the selected files' extension, mimetype, format and PRONOM identifier with provided values.";
+  }
+
+  @Override
+  public void init() {
+    // do nothing
+  }
+
+  @Override
+  public void shutdown() {
+    // do nothing
+  }
+
+  @Override
+  public String getName() {
+    return getStaticName();
+  }
+
+  @Override
+  public String getDescription() {
+    return getStaticDescription();
+  }
+
+  @Override
+  public String getVersionImpl() {
+    return "1.0";
+  }
+
+  @Override
+  public List<PluginParameter> getParameters() {
+    ArrayList<PluginParameter> parameters = new ArrayList<>();
+    parameters.add(pluginParameters.get(RodaConstants.PLUGIN_PARAMS_MIMETYPE));
+    parameters.add(pluginParameters.get(RodaConstants.PLUGIN_PARAMS_FORMAT));
+    parameters.add(pluginParameters.get(RodaConstants.PLUGIN_PARAMS_FORMAT_VERSION));
+    parameters.add(pluginParameters.get(RodaConstants.PLUGIN_PARAMS_PRONOM));
+    return parameters;
+  }
+
+  @Override
+  public void setParameterValues(Map<String, String> parameters) throws InvalidParameterException {
+    super.setParameterValues(parameters);
+    mimetype = parameters.get(RodaConstants.PLUGIN_PARAMS_MIMETYPE);
+    format = parameters.get(RodaConstants.PLUGIN_PARAMS_FORMAT);
+    formatVersion = parameters.get(RodaConstants.PLUGIN_PARAMS_FORMAT_VERSION);
+    pronom = parameters.get(RodaConstants.PLUGIN_PARAMS_PRONOM);
+  }
+
+  @Override
+  public Report execute(IndexService index, ModelService model, StorageService storage,
+    List<LiteOptionalWithCause> liteList) throws PluginException {
+    return PluginHelper.processObjects(this, new RODAObjectsProcessingLogic<File>() {
+      @Override
+      public void process(IndexService index, ModelService model, StorageService storage, Report report, Job cachedJob,
+        JobPluginInfo jobPluginInfo, Plugin<File> plugin, List<File> objects) {
+        processFiles(index, model, storage, report, jobPluginInfo, cachedJob, objects);
+      }
+    }, index, model, storage, liteList);
+  }
+
+  private void processFiles(IndexService index, ModelService model, StorageService storage, Report report,
+    JobPluginInfo jobPluginInfo, Job cachedJob, List<File> files) {
+    JsonNode payload = createPayload();
+    for (File file : files) {
+      Report reportItem = PluginHelper.initPluginReportItem(this, file.getId(), File.class);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, false, cachedJob);
+      List<LinkingIdentifier> sources = new ArrayList<>();
+      try {
+        sources.add(setFileFormatMetadata(model, file, cachedJob.getId(), cachedJob.getUsername(), payload));
+        jobPluginInfo.incrementObjectsProcessedWithSuccess();
+        reportItem.setPluginState(PluginState.SUCCESS);
+      } catch (RequestNotValidException | NotFoundException | AuthorizationDeniedException | GenericException
+        | PluginException e) {
+        LOGGER.error("Error setting format metadata on file {}: {}", file.getId(), e.getMessage(), e);
+
+        jobPluginInfo.incrementObjectsProcessedWithFailure();
+        reportItem.setPluginState(PluginState.FAILURE)
+          .setPluginDetails("Error setting format metadata on file " + file.getId() + ": " + e.getMessage());
+      }
+
+      try {
+        PluginHelper.createPluginEvent(this, file.getAipId(), file.getRepresentationId(), file.getPath(), file.getId(),
+          model, index, sources, null, reportItem.getPluginState(), "", true, cachedJob);
+      } catch (AuthorizationDeniedException | RequestNotValidException | NotFoundException | GenericException
+        | ValidationException | AlreadyExistsException e) {
+        LOGGER.error("Error creating event: {}", e.getMessage(), e);
+      }
+
+      report.addReport(reportItem);
+      PluginHelper.updatePartialJobReport(this, model, reportItem, true, cachedJob);
+    }
+  }
+
+  private JsonNode createPayload() {
+    JsonMapper mapper = new JsonMapper();
+    ObjectNode payloadJson = mapper.createObjectNode();
+    ArrayNode matchesArray = payloadJson.putArray(RodaConstants.SIEGFRIED_PAYLOAD_MATCHES);
+    ObjectNode matchesNode = matchesArray.addObject();
+
+    matchesNode.put(RodaConstants.SIEGFRIED_PAYLOAD_MATCH_NS, RodaConstants.SIEGFRIED_PAYLOAD_MATCH_NS_PRONOM);
+    if (mimetype != null) {
+      matchesNode.put(RodaConstants.SIEGFRIED_PAYLOAD_MATCH_MIMETYPE, mimetype);
+    }
+    if (format != null) {
+      matchesNode.put(RodaConstants.SIEGFRIED_PAYLOAD_MATCH_FORMAT_DESIGNATION, format);
+    }
+    if (formatVersion != null) {
+      matchesNode.put(RodaConstants.SIEGFRIED_PAYLOAD_MATCH_FORMAT_VERSION, formatVersion);
+    }
+    if (pronom != null) {
+      matchesNode.put(RodaConstants.SIEGFRIED_PAYLOAD_MATCH_ID, pronom);
+    }
+
+    return payloadJson;
+  }
+
+  private LinkingIdentifier setFileFormatMetadata(ModelService model, File file, String jobId, String username,
+    JsonNode payloadJson)
+    throws GenericException, RequestNotValidException, NotFoundException, AuthorizationDeniedException,
+    PluginException {
+    StoragePath fileDataPath = ModelUtils.getFileStoragePath(file);
+    StorageService tmpStorageService = ModelUtils.resolveTemporaryResourceShallow(jobId, model.getStorage(),
+      ModelUtils.getAIPStoragePath(file.getAipId()));
+    LinkingIdentifier source = null;
+    try (DirectResourceAccess directAccess = tmpStorageService.getDirectAccess(fileDataPath)) {
+      List<String> jsonFilePath = new ArrayList<>();
+      jsonFilePath.add(file.getId());
+
+      Path fileFsPath = directAccess.getPath();
+      Path fullFsPath = Paths.get(FilenameUtils.normalize(fileFsPath.toString()));
+      Path relativeFsPath = fileFsPath.relativize(fullFsPath);
+
+      for (int i = 0; i < relativeFsPath.getNameCount()
+        && StringUtils.isNotBlank(relativeFsPath.getName(i).toString()); i++) {
+        jsonFilePath.add(relativeFsPath.getName(i).toString());
+      }
+
+      jsonFilePath.remove(jsonFilePath.size() - 1);
+      String jsonFileId = fullFsPath.getFileName().toString();
+
+      ContentPayload payload = new StringContentPayload(payloadJson.toString());
+      model.createOrUpdateOtherMetadata(file.getAipId(), file.getRepresentationId(), jsonFilePath, jsonFileId,
+        SiegfriedPlugin.FILE_SUFFIX, RodaConstants.OTHER_METADATA_TYPE_SIEGFRIED, payload, username, false);
+
+      String updatedFormat = format;
+      String updatedFormatVersion = formatVersion;
+      String updatedPronomIdentifier = pronom;
+      String updatedMimetype = mimetype;
+
+      PremisV3Utils.updateFormatPreservationMetadata(model, file.getAipId(), file.getRepresentationId(), jsonFilePath,
+        jsonFileId, updatedFormat, updatedFormatVersion, updatedPronomIdentifier, updatedMimetype,
+        Arrays.asList(RodaConstants.PRESERVATION_FORMAT_NOTE_MANUAL), username, true);
+
+      source = PluginHelper.getLinkingIdentifier(file.getAipId(), file.getRepresentationId(), jsonFilePath, jsonFileId,
+        RodaConstants.PRESERVATION_LINKING_OBJECT_SOURCE);
+      model.notifyFileUpdated(file);
+    } catch (IOException e) {
+      throw new PluginException("Could not create direct access StorageService for file " + file.getId(), e);
+    }
+    return source;
+  }
+
+  @Override
+  public RodaConstants.PreservationEventType getPreservationEventType() {
+    return RodaConstants.PreservationEventType.UPDATE;
+  }
+
+  @Override
+  public String getPreservationEventDescription() {
+    return "Changed files' format metadata";
+  }
+
+  @Override
+  public String getPreservationEventSuccessMessage() {
+    return "File formats were updated and recorded in PREMIS objects.";
+  }
+
+  @Override
+  public String getPreservationEventFailureMessage() {
+    return "Failed to update file formats in the package.";
+  }
+
+  @Override
+  public PluginType getType() {
+    return PluginType.INTERNAL;
+  }
+
+  @Override
+  public List<String> getCategories() {
+    return Arrays.asList(RodaConstants.PLUGIN_CATEGORY_MISC);
+  }
+
+  @Override
+  public Plugin cloneMe() {
+    EditFileFormatPlugin editFileFormatPlugin = new EditFileFormatPlugin();
+    editFileFormatPlugin.init();
+    return editFileFormatPlugin;
+  }
+
+  @Override
+  public boolean areParameterValuesValid() {
+    if (mimetype != null && !mimetype.matches(RodaConstants.REGEX_MIME)) {
+      return false;
+    }
+    if (pronom != null && !pronom.matches(RodaConstants.REGEX_PUID)) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public List<Class<File>> getObjectClasses() {
+    return Arrays.asList(File.class);
+  }
+
+  @Override
+  public Report beforeAllExecute(IndexService index, ModelService model, StorageService storage)
+    throws PluginException {
+    // do nothing
+    return null;
+  }
+
+  @Override
+  public Report afterAllExecute(IndexService index, ModelService model, StorageService storage) throws PluginException {
+    // do nothing
+    return null;
+  }
+}

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/EditFileFormatPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/EditFileFormatPlugin.java
@@ -187,6 +187,7 @@ public class EditFileFormatPlugin extends AbstractPlugin<File> {
 
   private Report validateParameters() {
     Report reportItem = PluginHelper.initPluginReportItem(this, null, File.class);
+    reportItem.setPluginState(PluginState.SUCCESS);
     if (mimetype != null && !mimetype.isEmpty() && !mimetype.matches(RodaConstants.REGEX_MIME)) {
       reportItem.setPluginState(PluginState.FAILURE).addPluginDetails(
         "Invalid mimetype (expecting a string that conforms to \"" + RodaConstants.REGEX_MIME + "\".");

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/EditFileFormatPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/preservation/EditFileFormatPlugin.java
@@ -54,7 +54,7 @@ public class EditFileFormatPlugin extends AbstractPlugin<File> {
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_MIMETYPE,
       PluginParameter
         .getBuilder(RodaConstants.PLUGIN_PARAMS_MIMETYPE, "Mimetype", PluginParameter.PluginParameterType.STRING)
-        .withDescription("The Mimetype to set for all selected files.").build());
+        .withDescription("The MIME type to set for all selected files.").build());
     pluginParameters.put(RodaConstants.PLUGIN_PARAMS_FORMAT,
       PluginParameter
         .getBuilder(RodaConstants.PLUGIN_PARAMS_FORMAT, "Format", PluginParameter.PluginParameterType.STRING)
@@ -80,7 +80,7 @@ public class EditFileFormatPlugin extends AbstractPlugin<File> {
   }
 
   public static String getStaticDescription() {
-    return "Overwrites the selected files' extension, mimetype, format and PRONOM identifier with provided values.";
+    return "Overwrites the selected files' extension, MIME type, format and PRONOM identifier with provided values.";
   }
 
   @Override
@@ -188,13 +188,13 @@ public class EditFileFormatPlugin extends AbstractPlugin<File> {
   private Report validateParameters() {
     Report reportItem = PluginHelper.initPluginReportItem(this, null, File.class);
     reportItem.setPluginState(PluginState.SUCCESS);
-    if (mimetype != null && !mimetype.isEmpty() && !mimetype.matches(RodaConstants.REGEX_MIME)) {
+    if (StringUtils.isNotBlank(mimetype) && !mimetype.matches(RodaConstants.REGEX_MIME)) {
       reportItem.setPluginState(PluginState.FAILURE).addPluginDetails(
-        "Invalid mimetype (expecting a string that conforms to \"" + RodaConstants.REGEX_MIME + "\".");
+        "Invalid MIME type (expecting a string that conforms to \"" + RodaConstants.REGEX_MIME + "\".");
     }
-    if (pronom != null && !pronom.isEmpty() && !pronom.matches(RodaConstants.REGEX_PUID)) {
+    if (StringUtils.isNotBlank(pronom) && !pronom.matches(RodaConstants.REGEX_PUID)) {
       reportItem.setPluginState(PluginState.FAILURE).addPluginDetails(
-        "Invalid pronom identifier (expecting a string that conforms to \"" + RodaConstants.REGEX_PUID + "\".");
+        "Invalid PRONOM identifier (expecting a string that conforms to \"" + RodaConstants.REGEX_PUID + "\".");
     }
     return reportItem;
   }


### PR DESCRIPTION
- Added an internal plugin for changing a plugin's format metadata
  - The plugin allows users to set a file's mimetype, PRONOM identifier, format designation, and format version
  - Files altered with this plugin are given the "manual" note in their PREMIS file format note
- SiegfriedPlugin now has a parameter, set to false by omission, that needs to be set to true in order to overwrite format data on files whose PREMIS format metadata was manually edited
  - Items processed by SiegfriedPlugin that were not altered because of this parameter are marked as Skipped