### PR TITLE
Generate risk incidences when Siegfried outputs warnings on format identification

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -1422,6 +1422,7 @@ public final class RodaConstants {
   public static final String PLUGIN_PARAMS_FORMAT = "parameter.format";
   public static final String PLUGIN_PARAMS_FORMAT_VERSION = "parameter.format_version";
   public static final String PLUGIN_PARAMS_PRONOM = "parameter.pronom";
+  public static final String PLUGIN_PARAMS_CLEAR_INCIDENCES = "parameter.clear_incidences";
 
   public static final String PLUGIN_CATEGORY_CONVERSION = "conversion";
   public static final String PLUGIN_CATEGORY_CHARACTERIZATION = "characterization";
@@ -1572,6 +1573,9 @@ public final class RodaConstants {
   public static final String RISK_INCIDENCE_FILE_PATH_COMPUTED_SEPARATOR = "/";
   public static final String RISK_INCIDENCE_FILE_EXTENSION = ".json";
 
+  /* Risk Ids */
+  public static final String RISK_ID_SIEGFRIED_IDENTIFICATION_WARNING = "urn:siegfried:r1";
+
   /* Representation information */
   public static final String REPRESENTATION_INFORMATION_ID = "id";
   public static final String REPRESENTATION_INFORMATION_NAME = "name";
@@ -1702,6 +1706,7 @@ public final class RodaConstants {
 
   /* Siegfriend payload fields */
   public static final String SIEGFRIED_PAYLOAD_MATCHES = "matches";
+  public static final String SIEGFRIED_PAYLOAD_MATCH_WARNING = "warning";
   public static final String SIEGFRIED_PAYLOAD_MATCH_NS = "ns";
   public static final String SIEGFRIED_PAYLOAD_MATCH_NS_PRONOM = "pronom";
   public static final String SIEGFRIED_PAYLOAD_MATCH_MIMETYPE = "mime";
@@ -1744,6 +1749,7 @@ public final class RodaConstants {
   public static final String PRESERVATION_REGISTRY_MIME = "mime";
 
   public static final String PRESERVATION_FORMAT_NOTE_MANUAL = "manual";
+  public static final String PRESERVATION_FORMAT_NOTE_SIEGFRIED_WARNING = "SIEGFRIED WARNING";
 
   public static final String PREMIS_RELATIONSHIP_TYPE_STRUCTURAL = "structural";
   public static final String PREMIS_RELATIONSHIP_SUBTYPE_HASPART = "hasPart";

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/CountRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/index/CountRequest.java
@@ -49,7 +49,15 @@ public class CountRequest implements Serializable {
     return filter;
   }
 
+  public void setFilter(Filter filter) {
+    this.filter = filter;
+  }
+
   public boolean isOnlyActive() {
     return onlyActive;
+  }
+
+  public void setOnlyActive(boolean onlyActive) {
+    this.onlyActive = onlyActive;
   }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPlugin.java
@@ -150,7 +150,7 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
                 if (aip.getRepresentations() != null && !aip.getRepresentations().isEmpty()) {
                   for (Representation representation : aip.getRepresentations()) {
                     LOGGER.debug("Processing representation {} of AIP {}", representation.getId(), aip.getId());
-                    List<LinkingIdentifier> newSources = SiegfriedPluginUtils.runSiegfriedOnRepresentation(model,
+                    List<LinkingIdentifier> newSources = SiegfriedPluginUtils.runSiegfriedOnRepresentation(model, index,
                       representation, cachedJob.getId(), cachedJob.getUsername(), overwriteManual);
                     if (!newSources.isEmpty()) {
                       sources.addAll(newSources);
@@ -180,7 +180,7 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
               if (aip.getRepresentations() != null && !aip.getRepresentations().isEmpty()) {
                 for (Representation representation : aip.getRepresentations()) {
                   LOGGER.debug("Processing representation {} of AIP {}", representation.getId(), aip.getId());
-                  List<LinkingIdentifier> newSources = SiegfriedPluginUtils.runSiegfriedOnRepresentation(model,
+                  List<LinkingIdentifier> newSources = SiegfriedPluginUtils.runSiegfriedOnRepresentation(model, index,
                     representation, cachedJob.getId(), cachedJob.getUsername(), overwriteManual);
                   if (!newSources.isEmpty()) {
                     sources.addAll(newSources);
@@ -203,7 +203,7 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
               }
             }
           } catch (PluginException | NotFoundException | GenericException | RequestNotValidException
-            | AuthorizationDeniedException e) {
+            | AuthorizationDeniedException | AlreadyExistsException e) {
             LOGGER.error("Error running Siegfried {}: {}", aip.getId(), e.getMessage(), e);
 
             jobPluginInfo.incrementObjectsProcessedWithFailure();
@@ -225,7 +225,7 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
               for (Representation representation : filteredList) {
                 try {
                   LOGGER.debug("Processing representation {} of AIP {}", representation.getId(), aip.getId());
-                  sources.addAll(SiegfriedPluginUtils.runSiegfriedOnRepresentation(model, representation,
+                  sources.addAll(SiegfriedPluginUtils.runSiegfriedOnRepresentation(model, index, representation,
                     cachedJob.getId(), cachedJob.getUsername(), overwriteManual));
                   if (sources.isEmpty()) {
                     state = PluginState.SKIPPED;
@@ -283,7 +283,8 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
       PluginHelper.updatePartialJobReport(this, model, reportItem, false, cachedJob);
       LOGGER.debug("Processing representation {} of AIP {}", representation.getId(), representation.getAipId());
       try {
-        sources.addAll(SiegfriedPluginUtils.runSiegfriedOnRepresentation(model, representation, cachedJob.getId(),
+        sources.addAll(SiegfriedPluginUtils.runSiegfriedOnRepresentation(model, index, representation,
+          cachedJob.getId(),
           cachedJob.getUsername(), overwriteManual));
         if (sources.isEmpty()) {
           jobPluginInfo.incrementObjectsProcessedWithSkipped();
@@ -295,7 +296,7 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
           model.notifyRepresentationUpdated(representation).failOnError();
         }
       } catch (PluginException | NotFoundException | GenericException | RequestNotValidException
-        | AuthorizationDeniedException e) {
+        | AuthorizationDeniedException | AlreadyExistsException e) {
         LOGGER.error("Error running Siegfried {}: {}", representation.getAipId(), e.getMessage(), e);
 
         jobPluginInfo.incrementObjectsProcessedWithFailure();
@@ -331,7 +332,8 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
         file.getAipId());
 
       try {
-        sources.addAll(SiegfriedPluginUtils.runSiegfriedOnFile(model, file, cachedJob.getUsername(), overwriteManual));
+        sources.addAll(
+          SiegfriedPluginUtils.runSiegfriedOnFile(model, index, file, cachedJob.getUsername(), overwriteManual));
         if (sources.isEmpty()) {
           jobPluginInfo.incrementObjectsProcessedWithSkipped();
           reportItem.setPluginState(PluginState.SKIPPED)
@@ -341,7 +343,7 @@ public class SiegfriedPlugin<T extends IsRODAObject> extends AbstractAIPComponen
           reportItem.setPluginState(PluginState.SUCCESS);
         }
       } catch (PluginException | NotFoundException | GenericException | RequestNotValidException
-        | AuthorizationDeniedException e) {
+        | AuthorizationDeniedException | AlreadyExistsException e) {
         LOGGER.error("Error running Siegfried on file {}: {}", file.getId(), e.getMessage(), e);
 
         jobPluginInfo.incrementObjectsProcessedWithFailure();

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPluginUtils.java
@@ -264,7 +264,7 @@ public class SiegfriedPluginUtils {
               List<String> notes = new ArrayList<>();
               if (StringUtils.isNotBlank(warning.textValue())) {
                 notes.add(RodaConstants.PRESERVATION_FORMAT_NOTE_SIEGFRIED_WARNING + ": " + warning.textValue());
-                updateFileRiskIncidences(model, index, aipId, representationId, fileId, jsonFilePath,
+                updateFileRiskIncidences(model, index, aipId, representationId, jsonFileId, jsonFilePath,
                   warning.textValue());
               }
               PremisV3Utils.updateFormatPreservationMetadata(model, aipId, representationId, jsonFilePath, jsonFileId,

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPluginUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/characterization/SiegfriedPluginUtils.java
@@ -21,18 +21,27 @@ import org.apache.commons.lang3.StringUtils;
 import org.roda.core.RodaCoreFactory;
 import org.roda.core.common.PremisV3Utils;
 import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.exceptions.AlreadyExistsException;
 import org.roda.core.data.exceptions.AuthorizationDeniedException;
 import org.roda.core.data.exceptions.GenericException;
 import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.utils.JsonUtils;
 import org.roda.core.data.v2.IsRODAObject;
+import org.roda.core.data.v2.index.filter.Filter;
+import org.roda.core.data.v2.index.filter.FilterParameter;
+import org.roda.core.data.v2.index.filter.SimpleFilterParameter;
 import org.roda.core.data.v2.ip.File;
 import org.roda.core.data.v2.ip.Representation;
 import org.roda.core.data.v2.ip.StoragePath;
 import org.roda.core.data.v2.ip.metadata.LinkingIdentifier;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.PluginType;
+import org.roda.core.data.v2.risks.IncidenceStatus;
+import org.roda.core.data.v2.risks.RiskIncidence;
+import org.roda.core.data.v2.risks.SeverityLevel;
+import org.roda.core.index.IndexService;
+import org.roda.core.index.utils.IterableIndexResult;
 import org.roda.core.model.ModelService;
 import org.roda.core.model.utils.ModelUtils;
 import org.roda.core.plugins.PluginException;
@@ -142,9 +151,9 @@ public class SiegfriedPluginUtils {
   }
 
   public static <T extends IsRODAObject> List<LinkingIdentifier> runSiegfriedOnRepresentation(ModelService model,
+    IndexService index,
     Representation representation, String jobId, String username, boolean overwriteManual) throws GenericException,
-    RequestNotValidException,
-    NotFoundException, AuthorizationDeniedException, PluginException {
+    RequestNotValidException, NotFoundException, AuthorizationDeniedException, PluginException, AlreadyExistsException {
     StoragePath representationDataPath = ModelUtils.getRepresentationDataStoragePath(representation.getAipId(),
       representation.getId());
     StorageService storageService;
@@ -154,7 +163,7 @@ public class SiegfriedPluginUtils {
         ModelUtils.getAIPStoragePath(representation.getAipId()));
       try (DirectResourceAccess directAccess = tmpStorageService.getDirectAccess(representationDataPath)) {
         Path representationFsPath = directAccess.getPath();
-        return runSiegfriedOnRepresentationOrFile(model, representation.getAipId(), representation.getId(),
+        return runSiegfriedOnRepresentationOrFile(model, index, representation.getAipId(), representation.getId(),
           new ArrayList<>(), null, representationFsPath, username, overwriteManual);
       } catch (IOException e) {
         throw new GenericException(e);
@@ -171,7 +180,7 @@ public class SiegfriedPluginUtils {
     } else {
       try (DirectResourceAccess directAccess = model.getStorage().getDirectAccess(representationDataPath)) {
         Path representationFsPath = directAccess.getPath();
-        return runSiegfriedOnRepresentationOrFile(model, representation.getAipId(), representation.getId(),
+        return runSiegfriedOnRepresentationOrFile(model, index, representation.getAipId(), representation.getId(),
           new ArrayList<>(), null, representationFsPath, username, overwriteManual);
       } catch (IOException e) {
         throw new GenericException(e);
@@ -179,15 +188,15 @@ public class SiegfriedPluginUtils {
     }
   }
 
-  public static <T extends IsRODAObject> List<LinkingIdentifier> runSiegfriedOnFile(ModelService model, File file,
+  public static <T extends IsRODAObject> List<LinkingIdentifier> runSiegfriedOnFile(ModelService model,
+    IndexService index, File file,
     String username, boolean overwriteManual) throws GenericException, RequestNotValidException, NotFoundException,
-    AuthorizationDeniedException,
-    PluginException {
+    AuthorizationDeniedException, PluginException, AlreadyExistsException {
     StoragePath fileStoragePath = ModelUtils.getFileStoragePath(file);
 
     try (DirectResourceAccess directAccess = model.getStorage().getDirectAccess(fileStoragePath)) {
       Path filePath = directAccess.getPath();
-      List<LinkingIdentifier> sources = runSiegfriedOnRepresentationOrFile(model, file.getAipId(),
+      List<LinkingIdentifier> sources = runSiegfriedOnRepresentationOrFile(model, index, file.getAipId(),
         file.getRepresentationId(), file.getPath(), file.getId(), filePath, username, overwriteManual);
       model.notifyFileUpdated(file).failOnError();
       return sources;
@@ -197,10 +206,11 @@ public class SiegfriedPluginUtils {
   }
 
   private static <T extends IsRODAObject> List<LinkingIdentifier> runSiegfriedOnRepresentationOrFile(ModelService model,
-    String aipId, String representationId, List<String> fileDirectoryPath, String fileId, Path path, String username,
+    IndexService index, String aipId, String representationId, List<String> fileDirectoryPath, String fileId, Path path,
+    String username,
     Boolean overwriteManual)
-    throws RequestNotValidException, GenericException, NotFoundException, AuthorizationDeniedException,
-    PluginException {
+    throws RequestNotValidException, GenericException, NotFoundException, AuthorizationDeniedException, PluginException,
+    AlreadyExistsException {
     List<LinkingIdentifier> sources = new ArrayList<>();
 
     if (FSUtils.exists(path)) {
@@ -225,37 +235,95 @@ public class SiegfriedPluginUtils {
 
         jsonFilePath.remove(jsonFilePath.size() - 1);
 
-        if (!PremisV3Utils.formatWasManuallyModified(model, aipId, representationId, jsonFilePath, jsonFileId, username)
-          || overwriteManual) {
-          ContentPayload payload = new StringContentPayload(file.toString());
-          model.createOrUpdateOtherMetadata(aipId, representationId, jsonFilePath, jsonFileId,
-            SiegfriedPlugin.FILE_SUFFIX, RodaConstants.OTHER_METADATA_TYPE_SIEGFRIED, payload, username, false);
+        JsonNode matches = file.get(RodaConstants.SIEGFRIED_PAYLOAD_MATCHES);
+        if (matches != null) {
+          if (!PremisV3Utils.formatWasManuallyModified(model, aipId, representationId, jsonFilePath, jsonFileId,
+            username) || overwriteManual) {
+            ContentPayload payload = new StringContentPayload(file.toString());
+            model.createOrUpdateOtherMetadata(aipId, representationId, jsonFilePath, jsonFileId,
+              SiegfriedPlugin.FILE_SUFFIX, RodaConstants.OTHER_METADATA_TYPE_SIEGFRIED, payload, username, false);
 
-          sources.add(PluginHelper.getLinkingIdentifier(aipId, representationId, jsonFilePath, jsonFileId,
-            RodaConstants.PRESERVATION_LINKING_OBJECT_SOURCE));
+            sources.add(PluginHelper.getLinkingIdentifier(aipId, representationId, jsonFilePath, jsonFileId,
+              RodaConstants.PRESERVATION_LINKING_OBJECT_SOURCE));
 
-          // Update PREMIS files
-          final JsonNode matches = file.get("matches");
-          for (JsonNode match : matches) {
-            String format = null;
-            String version = null;
-            String pronom = null;
-            String mime = null;
+            // Update PREMIS files
+            for (JsonNode match : matches) {
+              String format = null;
+              String version = null;
+              String pronom = null;
+              String mime = null;
 
-            if ("pronom".equalsIgnoreCase(match.get("ns").textValue())) {
-              format = match.get("format").textValue();
-              version = match.get("version").textValue();
-              pronom = match.get("id").textValue();
-              mime = match.get("mime").textValue();
+              if ("pronom".equalsIgnoreCase(match.get("ns").textValue())) {
+                format = match.get("format").textValue();
+                version = match.get("version").textValue();
+                pronom = match.get("id").textValue();
+                mime = match.get("mime").textValue();
+              }
+
+              JsonNode warning = match.get(RodaConstants.SIEGFRIED_PAYLOAD_MATCH_WARNING);
+              List<String> notes = new ArrayList<>();
+              if (StringUtils.isNotBlank(warning.textValue())) {
+                notes.add(RodaConstants.PRESERVATION_FORMAT_NOTE_SIEGFRIED_WARNING + ": " + warning.textValue());
+                updateFileRiskIncidences(model, index, aipId, representationId, fileId, jsonFilePath,
+                  warning.textValue());
+              }
+              PremisV3Utils.updateFormatPreservationMetadata(model, aipId, representationId, jsonFilePath, jsonFileId,
+                format, version, pronom, mime, notes, username, true);
             }
-
-            PremisV3Utils.updateFormatPreservationMetadata(model, aipId, representationId, jsonFilePath, jsonFileId,
-              format, version, pronom, mime, new ArrayList<>(), username, true);
           }
         }
       }
     }
-
     return sources;
+  }
+
+  private static void updateFileRiskIncidences(ModelService model, IndexService index, String aipId,
+    String representationId, String fileId, List<String> filePath, String warning) throws RequestNotValidException,
+    GenericException, AuthorizationDeniedException, AlreadyExistsException, NotFoundException {
+    // Mitigate previous incidences
+    for (RiskIncidence incidence : getPreviousSiegfriedIncidences(model, index, fileId)) {
+      incidence.setStatus(IncidenceStatus.MITIGATED);
+      model.updateRiskIncidence(incidence, true);
+    }
+    // Create a new incidence
+    RiskIncidence riskIncidence = new RiskIncidence();
+    if (fileId != null) {
+      riskIncidence.setFileId(fileId);
+      riskIncidence.setFilePath(filePath);
+      riskIncidence.setObjectClass(File.class.getName());
+    } else {
+      riskIncidence.setObjectClass(Representation.class.getName());
+    }
+    riskIncidence.setRiskId(RodaConstants.RISK_ID_SIEGFRIED_IDENTIFICATION_WARNING);
+    riskIncidence.setDetectedBy(SiegfriedPlugin.getStaticName());
+    riskIncidence.setByPlugin(true);
+    riskIncidence.setStatus(IncidenceStatus.UNMITIGATED);
+    riskIncidence.setRepresentationId(representationId);
+    riskIncidence.setAipId(aipId);
+    riskIncidence.setDescription(warning);
+    riskIncidence.setFileId(fileId);
+    riskIncidence.setSeverity(SeverityLevel.LOW);
+    model.createRiskIncidence(riskIncidence, true);
+  }
+
+  public static List<RiskIncidence> getPreviousSiegfriedIncidences(ModelService model, IndexService index,
+    String fileId) throws RequestNotValidException, GenericException, AuthorizationDeniedException, NotFoundException {
+    List<RiskIncidence> riskIncidences = new ArrayList<>();
+    Filter filter = new Filter();
+    List<FilterParameter> filterParameters = new ArrayList<>();
+    filterParameters.add(new SimpleFilterParameter("riskId", RodaConstants.RISK_ID_SIEGFRIED_IDENTIFICATION_WARNING));
+    filterParameters.add(new SimpleFilterParameter("fileId", fileId));
+    filterParameters.add(new SimpleFilterParameter("status", IncidenceStatus.UNMITIGATED.name()));
+    filter.add(filterParameters);
+    try (IterableIndexResult<RiskIncidence> results = index.findAll(RiskIncidence.class, filter, true,
+      Arrays.asList("id", "status"))) {
+      for (RiskIncidence incidence : results) {
+        RiskIncidence modelIncidence = model.retrieveRiskIncidence(incidence.getId());
+        riskIncidences.add(modelIncidence);
+      }
+    } catch (IOException e) {
+      LOGGER.error("Error finding file id {}'s associated risk incidences", fileId, e);
+    }
+    return riskIncidences;
   }
 }

--- a/roda-core/roda-core/src/main/resources/default/data/storage/risk/urn:siegfried:r1.json
+++ b/roda-core/roda-core/src/main/resources/default/data/storage/risk/urn:siegfried:r1.json
@@ -1,0 +1,24 @@
+{
+  "categories": [
+    "Content characterization"
+  ],
+  "id": "urn:siegfried:r1",
+  "name": "File format identification issue",
+  "description": "File format identification process has identified possible issues while identifying file formats.",
+  "notes": "The file format identification process may have reported warnings during the matching process of the file format identifier signatures. These are not strictly errors but may still warrant further investigation. Common warnings include being unable to detect the file format or a mismatch between the identified file format via identifier signatures and the file name extension.",
+  "preMitigationNotes": "\n- The repository cannot reliably confirm the technical metadata of the affected files",
+  "mitigationOwner": "Preservation",
+  "mitigationStrategy": "Manually review and/or edit the technical metadata of affected files in order to verify the relevance of the produced warnings.",
+  "preMitigationProbability": 4,
+  "preMitigationImpact": 3,
+  "preMitigationSeverity": 12,
+  "preMitigationSeverityLevel": "MODERATE",
+  "identifiedBy": "Risk automatically detected by the File Format Identification plugin \"roda.core.plugins.plugins.base.characterization.SiegfriedPlugin\".",
+  "mitigationOwnerType": "",
+  "createdBy": "admin",
+  "createdOn": 1721257200000,
+  "updatedBy": "admin",
+  "updatedOn": 1721257200000,
+  "identifiedOn": "1721257200000"
+}
+        

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskIncidenceController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/RiskIncidenceController.java
@@ -73,7 +73,7 @@ public class RiskIncidenceController implements RiskIncidenceRestService, Export
   }
 
   @Override
-  public LongResponse count(CountRequest countRequest) {
+  public LongResponse count(@RequestBody CountRequest countRequest) {
     RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
     if (UserUtility.hasPermissions(requestContext.getUser(), RodaConstants.PERMISSION_METHOD_FIND_RISK_INCIDENCE)) {
       return new LongResponse(indexService.count(RiskIncidence.class, countRequest, requestContext));


### PR DESCRIPTION
- A new risk pertaining to Siegfried file format detector warnings was added
- SiegfriedPlugin now generates risk incidences of the aforementioned risk when a warning is output on file format detection
  - If previous incidences of this risk exist on the source files when this plugin is run, then they are automatically set as "Mitigated" by the plugin (new "Unmitigated" incidences may still be created during this execution) 
- SiegfriedPlugin now writes a note to all the PREMIS Format Notes for source files that includes any output Siegfried warning
- EditFileFormatPlugin has a new boolean parameter that will clear the source files' risk incidences/PREMIS notes relating Siefried warnings
  - If this parameter is left as false (default), PREMIS notes will be preserved and no risk incidences will be modified 