### PR TITLE
Added missing SelectedItemsRequest implements; Simplified API requests

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -721,6 +721,7 @@ public final class RodaConstants {
   public static final String CONTROLLER_NOTIFICATION_ID_PARAM = "notificationId";
   public static final String CONTROLLER_NOTIFICATION_TOKEN_PARAM = "token";
   public static final String CONTROLLER_JOB_PARAM = "job";
+  public static final String CONTROLLER_JOB_CREATE_REQUEST = "createJobRequest";
   public static final String CONTROLLER_JOB_ID_PARAM = "jobId";
   public static final String CONTROLLER_JOB_JUST_FAILED_PARAM = "justFailed";
   public static final String CONTROLLER_JOB_REPORT_ID_PARAM = "jobReportId";

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/SelectedItemsUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/SelectedItemsUtils.java
@@ -1,11 +1,15 @@
 package org.roda.core.data.utils;
 
+import org.roda.core.data.v2.generics.select.SelectedItemsAllRequest;
 import org.roda.core.data.v2.generics.select.SelectedItemsFilterRequest;
 import org.roda.core.data.v2.generics.select.SelectedItemsListRequest;
+import org.roda.core.data.v2.generics.select.SelectedItemsNoneRequest;
 import org.roda.core.data.v2.generics.select.SelectedItemsRequest;
 import org.roda.core.data.v2.index.select.SelectedItems;
+import org.roda.core.data.v2.index.select.SelectedItemsAll;
 import org.roda.core.data.v2.index.select.SelectedItemsFilter;
 import org.roda.core.data.v2.index.select.SelectedItemsList;
+import org.roda.core.data.v2.index.select.SelectedItemsNone;
 
 /**
  * @author Miguel Guimarães <mguimaraes@keep.pt>
@@ -25,6 +29,10 @@ public class SelectedItemsUtils {
       request.setFilter(((SelectedItemsFilter<?>) items).getFilter());
       request.setJustActive(((SelectedItemsFilter<?>) items).justActive());
       return request;
+    } else if (items instanceof SelectedItemsNone<?>) {
+      return new SelectedItemsNoneRequest();
+    } else if (items instanceof SelectedItemsAll<?>) {
+      return new SelectedItemsAllRequest();
     }
 
     return new SelectedItemsListRequest();

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsAllRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsAllRequest.java
@@ -1,0 +1,18 @@
+package org.roda.core.data.v2.generics.select;
+
+import java.io.Serial;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * @author Alexandre Flores <aflores@keep.pt>
+ */
+@JsonTypeName("SelectedItemsAllRequest")
+public class SelectedItemsAllRequest implements SelectedItemsRequest {
+  @Serial
+  private static final long serialVersionUID = 165811248428623687L;
+
+  public SelectedItemsAllRequest() {
+    // do nothing
+  }
+}

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsNoneRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsNoneRequest.java
@@ -1,0 +1,18 @@
+package org.roda.core.data.v2.generics.select;
+
+import java.io.Serial;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * @author Alexandre Flores <aflores@keep.pt>
+ */
+@JsonTypeName("SelectedItemsNoneRequest")
+public class SelectedItemsNoneRequest implements SelectedItemsRequest {
+  @Serial
+  private static final long serialVersionUID = 4225008000954460297L;
+
+  public SelectedItemsNoneRequest() {
+    // do nothing
+  }
+}

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/generics/select/SelectedItemsRequest.java
@@ -15,10 +15,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, visible = true, include = JsonTypeInfo.As.PROPERTY, property = "@type")
 @JsonSubTypes({@JsonSubTypes.Type(value = SelectedItemsListRequest.class, name = "SelectedItemsListRequest"),
-  @JsonSubTypes.Type(value = SelectedItemsFilterRequest.class, name = "SelectedItemsFilterRequest")})
+  @JsonSubTypes.Type(value = SelectedItemsFilterRequest.class, name = "SelectedItemsFilterRequest"),
+  @JsonSubTypes.Type(value = SelectedItemsNoneRequest.class, name = "SelectedItemsNoneRequest"),
+  @JsonSubTypes.Type(value = SelectedItemsAllRequest.class, name = "SelectedItemsAllRequest")})
 @Schema(type = "object", subTypes = {SelectedItemsListRequest.class,
-  SelectedItemsFilterRequest.class}, discriminatorMapping = {
+  SelectedItemsFilterRequest.class, SelectedItemsNoneRequest.class,
+  SelectedItemsAllRequest.class}, discriminatorMapping = {
     @DiscriminatorMapping(value = "SelectedItemsListRequest", schema = SelectedItemsListRequest.class),
-    @DiscriminatorMapping(value = "SelectedItemsFilterRequest", schema = SelectedItemsFilterRequest.class)}, discriminatorProperty = "@type")
+    @DiscriminatorMapping(value = "SelectedItemsFilterRequest", schema = SelectedItemsFilterRequest.class),
+    @DiscriminatorMapping(value = "SelectedItemsNoneRequest", schema = SelectedItemsNoneRequest.class),
+    @DiscriminatorMapping(value = "SelectedItemsAllRequest", schema = SelectedItemsAllRequest.class)}, discriminatorProperty = "@type")
 public interface SelectedItemsRequest extends Serializable {
 }

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/CreateJobRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/CreateJobRequest.java
@@ -1,0 +1,84 @@
+package org.roda.core.data.v2.jobs;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Map;
+
+import org.roda.core.data.v2.generics.select.SelectedItemsRequest;
+
+/**
+ * @author Alexandre Flores <aflores@keep.pt>
+ */
+public class CreateJobRequest implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = 5136924368954184386L;
+
+  private String name;
+  private String plugin;
+  private Map<String, String> pluginParameters;
+  private SelectedItemsRequest sourceObjects;
+  private String sourceObjectsClass;
+  private String priority;
+  private String parallelism;
+
+  public CreateJobRequest() {
+    // do nothing
+  }
+
+  public String getParallelism() {
+    return parallelism;
+  }
+
+  public void setParallelism(String parallelism) {
+    this.parallelism = parallelism;
+  }
+
+  public String getPriority() {
+    return priority;
+  }
+
+  public void setPriority(String priority) {
+    this.priority = priority;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getPlugin() {
+    return plugin;
+  }
+
+  public void setPlugin(String plugin) {
+    this.plugin = plugin;
+  }
+
+  public Map<String, String> getPluginParameters() {
+    return pluginParameters;
+  }
+
+  public void setPluginParameters(Map<String, String> pluginParameters) {
+    this.pluginParameters = pluginParameters;
+  }
+
+  public SelectedItemsRequest getSourceObjects() {
+    return sourceObjects;
+  }
+
+  public void setSourceObjects(SelectedItemsRequest sourceObjects) {
+    this.sourceObjects = sourceObjects;
+  }
+
+  public String getSourceObjectsClass() {
+    return sourceObjectsClass;
+  }
+
+  public void setSourceObjectsClass(String sourceObjectsClass) {
+    this.sourceObjectsClass = sourceObjectsClass;
+  }
+}

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/RegisterUserRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/RegisterUserRequest.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * @author António Lindo <alindo@keep.pt>
  */
 @JsonInclude(JsonInclude.Include.ALWAYS)
-public class CreateUserRequest implements Serializable {
+public class RegisterUserRequest implements Serializable {
 
   @Serial
   private static final long serialVersionUID = 2288990827132952813L;
@@ -22,24 +22,19 @@ public class CreateUserRequest implements Serializable {
   private String email;
   private String name;
   private String fullName;
-  private Set<String> groups;
-  private boolean guest;
   private SecureString password;
   private Set<MetadataValue> values;
 
-  public CreateUserRequest(String email, String name, String fullName, Set<String> groups, boolean guest,
-    SecureString password, Set<MetadataValue> values) {
+  public RegisterUserRequest(String email, String name, String fullName, SecureString password,
+    Set<MetadataValue> values) {
     this.email = email;
     this.name = name;
     this.fullName = fullName;
-    this.groups = groups;
-    this.guest = guest;
     this.password = password;
     this.values = values;
   }
 
-  public CreateUserRequest() {
-    this.groups = new HashSet<>();
+  public RegisterUserRequest() {
     this.password = new SecureString();
     this.values = new HashSet<>();
   }
@@ -66,22 +61,6 @@ public class CreateUserRequest implements Serializable {
 
   public void setFullName(String fullName) {
     this.fullName = fullName;
-  }
-
-  public Set<String> getGroups() {
-    return groups;
-  }
-
-  public void setGroups(Set<String> groups) {
-    this.groups = groups;
-  }
-
-  public boolean getGuest() {
-    return guest;
-  }
-
-  public void setGuest(boolean guest) {
-    this.guest = guest;
   }
 
   public Set<MetadataValue> getValues() {

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/UpdateUserRequest.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/user/requests/UpdateUserRequest.java
@@ -1,0 +1,62 @@
+package org.roda.core.data.v2.user.requests;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.roda.core.data.common.SecureString;
+import org.roda.core.data.v2.generics.MetadataValue;
+import org.roda.core.data.v2.user.User;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * @author António Lindo <alindo@keep.pt>
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public class UpdateUserRequest implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = -2706255856347304025L;
+
+  private User user;
+  private SecureString password;
+  private Set<MetadataValue> values;
+
+  public UpdateUserRequest(User user, SecureString password, Set<MetadataValue> values) {
+    this.user = user;
+    this.password = password;
+    this.values = values;
+  }
+
+  public UpdateUserRequest() {
+    this.user = new User();
+    this.password = new SecureString();
+    this.values = new HashSet<>();
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public void setUser(User user) {
+    this.user = user;
+  }
+
+  public Set<MetadataValue> getValues() {
+    return values;
+  }
+
+  public void setValues(Set<MetadataValue> values) {
+    this.values = values;
+  }
+
+  public SecureString getPassword() {
+    return password;
+  }
+
+  public void setPassword(SecureString password) {
+    this.password = password;
+  }
+}

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/MembersService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/MembersService.java
@@ -46,7 +46,7 @@ import org.roda.core.data.v2.user.Group;
 import org.roda.core.data.v2.user.RODAMember;
 import org.roda.core.data.v2.user.RodaPrincipal;
 import org.roda.core.data.v2.user.User;
-import org.roda.core.data.v2.user.requests.CreateUserRequest;
+import org.roda.core.data.v2.user.requests.UpdateUserRequest;
 import org.roda.core.data.v2.validation.ValidationException;
 import org.roda.core.index.IndexService;
 import org.roda.core.model.ModelService;
@@ -55,11 +55,11 @@ import org.roda.core.plugins.base.maintenance.ChangeRodaMemberStatusPlugin;
 import org.roda.core.util.IdUtils;
 import org.roda.wui.api.v2.exceptions.RESTException;
 import org.roda.wui.api.v2.utils.CommonServicesUtils;
+import org.roda.wui.api.v2.utils.RecaptchaUtils;
 import org.roda.wui.client.management.recaptcha.RecaptchaException;
 import org.roda.wui.common.ControllerAssistant;
 import org.roda.wui.common.client.tools.StringUtils;
 import org.roda.wui.common.server.ServerTools;
-import org.roda.wui.api.v2.utils.RecaptchaUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -291,7 +291,7 @@ public class MembersService {
     return RodaCoreFactory.getModelService().confirmUserEmail(username, email, emailConfirmationToken, true, true);
   }
 
-  public User updateUser(CreateUserRequest request) throws GenericException, AlreadyExistsException, NotFoundException,
+  public User updateUser(UpdateUserRequest request) throws GenericException, AlreadyExistsException, NotFoundException,
     AuthorizationDeniedException, ValidationException, RequestNotValidException {
     ModelService model = RodaCoreFactory.getModelService();
     IndexService index = RodaCoreFactory.getIndexService();
@@ -395,7 +395,7 @@ public class MembersService {
         user.setEmailConfirmationTokenExpirationDate(DateTime.now().plusDays(1).toDateTimeISO().toInstant().toString());
 
         try {
-          user = updateUser(new CreateUserRequest(user, null, null));
+          user = updateUser(new UpdateUserRequest(user, null, null));
           // 20170523 hsilva: need to set ip address for registering the action
           // as the above method returns a new instante of the modified user
           user.setIpAddress(ipAddress);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/utils/CommonServicesUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/utils/CommonServicesUtils.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
-import java.util.Set;
-import java.util.TreeSet;
 
 import org.roda.core.RodaCoreFactory;
 import org.roda.core.common.Messages;
@@ -19,22 +17,23 @@ import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.utils.JsonUtils;
 import org.roda.core.data.v2.IsRODAObject;
 import org.roda.core.data.v2.generics.MetadataValue;
+import org.roda.core.data.v2.generics.select.SelectedItemsAllRequest;
 import org.roda.core.data.v2.generics.select.SelectedItemsFilterRequest;
 import org.roda.core.data.v2.generics.select.SelectedItemsListRequest;
+import org.roda.core.data.v2.generics.select.SelectedItemsNoneRequest;
 import org.roda.core.data.v2.generics.select.SelectedItemsRequest;
 import org.roda.core.data.v2.index.IsIndexed;
 import org.roda.core.data.v2.index.select.SelectedItems;
+import org.roda.core.data.v2.index.select.SelectedItemsAll;
 import org.roda.core.data.v2.index.select.SelectedItemsFilter;
 import org.roda.core.data.v2.index.select.SelectedItemsList;
-import org.roda.core.data.v2.ip.IndexedAIP;
-import org.roda.core.data.v2.ip.IndexedRepresentation;
+import org.roda.core.data.v2.index.select.SelectedItemsNone;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.JobParallelism;
 import org.roda.core.data.v2.jobs.JobPriority;
 import org.roda.core.data.v2.jobs.PluginType;
 import org.roda.core.data.v2.user.User;
 import org.roda.core.util.IdUtils;
-import org.roda.wui.common.server.ServerTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,6 +113,10 @@ public class CommonServicesUtils {
       return SelectedItemsList.create(tClass, itemsListRequest.getIds());
     } else if (request instanceof SelectedItemsFilterRequest filterRequest) {
       return new SelectedItemsFilter<>(filterRequest.getFilter(), tClass.getName(), filterRequest.getJustActive());
+    } else if (request instanceof SelectedItemsNoneRequest) {
+      return new SelectedItemsNone<>();
+    } else if (request instanceof SelectedItemsAllRequest) {
+      return new SelectedItemsAll<>(tClass.getName());
     }
 
     throw new RequestNotValidException("Selected items must be either a list or a filter");

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/CreateUser.java
@@ -10,6 +10,20 @@
  */
 package org.roda.wui.client.management;
 
+import java.util.List;
+
+import org.roda.core.data.exceptions.EmailAlreadyExistsException;
+import org.roda.core.data.exceptions.UserAlreadyExistsException;
+import org.roda.core.data.v2.user.User;
+import org.roda.core.data.v2.user.requests.CreateUserRequest;
+import org.roda.wui.client.common.UserLogin;
+import org.roda.wui.client.common.utils.JavascriptUtils;
+import org.roda.wui.client.services.Services;
+import org.roda.wui.common.client.HistoryResolver;
+import org.roda.wui.common.client.tools.HistoryUtils;
+import org.roda.wui.common.client.tools.ListUtils;
+import org.roda.wui.common.client.widgets.Toast;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.i18n.client.LocaleInfo;
@@ -20,20 +34,8 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
-import config.i18n.client.ClientMessages;
-import org.roda.core.data.exceptions.EmailAlreadyExistsException;
-import org.roda.core.data.exceptions.UserAlreadyExistsException;
-import org.roda.core.data.v2.user.requests.CreateUserRequest;
-import org.roda.core.data.v2.user.User;
-import org.roda.wui.client.common.UserLogin;
-import org.roda.wui.client.common.utils.JavascriptUtils;
-import org.roda.wui.client.services.Services;
-import org.roda.wui.common.client.HistoryResolver;
-import org.roda.wui.common.client.tools.HistoryUtils;
-import org.roda.wui.common.client.tools.ListUtils;
-import org.roda.wui.common.client.widgets.Toast;
 
-import java.util.List;
+import config.i18n.client.ClientMessages;
 
 /**
  * @author Luis Faria
@@ -108,7 +110,8 @@ public class CreateUser extends Composite {
     if (userDataPanel.isValid()) {
       user = userDataPanel.getUser();
       Services services = new Services("Create RODA user", "create");
-      CreateUserRequest userOperations = new CreateUserRequest(user, null, userDataPanel.getUserExtra());
+      CreateUserRequest userOperations = new CreateUserRequest(user.getEmail(), user.getName(), user.getFullName(),
+        user.getGroups(), user.isGuest(), null, userDataPanel.getUserExtra());
       services.membersResource(s -> s.createUser(userOperations,  LocaleInfo.getCurrentLocale().getLocaleName())).whenComplete((createdUser, error) -> {
         if (createdUser != null) {
           HistoryUtils.newHistory(MemberManagement.RESOLVER);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/EditUser.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/EditUser.java
@@ -20,13 +20,11 @@ import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.v2.generics.select.SelectedItemsListRequest;
 import org.roda.core.data.v2.user.User;
 import org.roda.core.data.v2.user.requests.ChangeUserStatusRequest;
-import org.roda.core.data.v2.user.requests.CreateUserRequest;
+import org.roda.core.data.v2.user.requests.UpdateUserRequest;
 import org.roda.wui.client.common.UserLogin;
 import org.roda.wui.client.common.dialogs.Dialogs;
 import org.roda.wui.client.common.utils.JavascriptUtils;
 import org.roda.wui.client.ingest.process.ShowJob;
-import org.roda.wui.client.management.access.AccessKeyTablePanel;
-import org.roda.wui.client.management.access.CreateAccessKey;
 import org.roda.wui.client.services.Services;
 import org.roda.wui.common.client.HistoryResolver;
 import org.roda.wui.common.client.tools.HistoryUtils;
@@ -41,7 +39,6 @@ import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
@@ -161,7 +158,7 @@ public class EditUser extends Composite {
         final User updatedUser = userDataPanel.getUser();
         try (SecureString password = getPassword()) {
           Services services = new Services("Update User", "update");
-          CreateUserRequest userOperations = new CreateUserRequest(updatedUser, password, userDataPanel.getUserExtra());
+          UpdateUserRequest userOperations = new UpdateUserRequest(updatedUser, password, userDataPanel.getUserExtra());
           services.membersResource(s -> s.updateUser(userOperations)).whenComplete((res, error) -> {
             if (error == null) {
               HistoryUtils.newHistory(ShowUser.RESOLVER, res.getId());

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Profile.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Profile.java
@@ -16,8 +16,8 @@ import java.util.List;
 import org.roda.core.data.common.SecureString;
 import org.roda.core.data.exceptions.AlreadyExistsException;
 import org.roda.core.data.exceptions.NotFoundException;
-import org.roda.core.data.v2.user.requests.CreateUserRequest;
 import org.roda.core.data.v2.user.User;
+import org.roda.core.data.v2.user.requests.UpdateUserRequest;
 import org.roda.wui.client.common.UserLogin;
 import org.roda.wui.client.common.utils.JavascriptUtils;
 import org.roda.wui.client.services.Services;
@@ -147,7 +147,7 @@ public class Profile extends Composite {
         final User user = userDataPanel.getUser();
         try (SecureString password = getPassword()) {
           Services services = new Services("Update User", "update");
-          CreateUserRequest userOperations = new CreateUserRequest(user, password, userDataPanel.getUserExtra());
+          UpdateUserRequest userOperations = new UpdateUserRequest(user, password, userDataPanel.getUserExtra());
           services.membersResource(s -> s.updateMyUser(userOperations)).whenComplete((updatedUser, error) -> {
             if (error == null) {
               UserLogin.getInstance().updateLoggedUser(updatedUser);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Register.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/Register.java
@@ -10,24 +10,17 @@
  */
 package org.roda.wui.client.management;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.i18n.client.LocaleInfo;
-import com.google.gwt.uibinder.client.UiBinder;
-import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.uibinder.client.UiHandler;
-import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.Widget;
-import config.i18n.client.ClientMessages;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.common.SecureString;
 import org.roda.core.data.exceptions.EmailAlreadyExistsException;
 import org.roda.core.data.exceptions.UserAlreadyExistsException;
-import org.roda.core.data.v2.user.requests.CreateUserRequest;
 import org.roda.core.data.v2.generics.MetadataValue;
 import org.roda.core.data.v2.user.User;
+import org.roda.core.data.v2.user.requests.RegisterUserRequest;
 import org.roda.wui.client.common.UserLogin;
 import org.roda.wui.client.common.dialogs.Dialogs;
 import org.roda.wui.client.common.utils.JavascriptUtils;
@@ -43,9 +36,18 @@ import org.roda.wui.common.client.tools.HistoryUtils;
 import org.roda.wui.common.client.tools.StringUtils;
 import org.roda.wui.common.client.widgets.Toast;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.i18n.client.LocaleInfo;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.Widget;
+
+import config.i18n.client.ClientMessages;
 
 /**
  * @author Luis Faria
@@ -167,7 +169,8 @@ public class Register extends Composite {
         final String recaptcha = recaptchaResponse;
 
         Services services = new Services("Register RODA user", "register");
-        CreateUserRequest userRequest = new CreateUserRequest(user, password, userDataPanel.getUserExtra());
+        RegisterUserRequest userRequest = new RegisterUserRequest(user.getEmail(), user.getName(), user.getFullName(),
+          password, userDataPanel.getUserExtra());
         services.membersResource(s -> s.registerUser(userRequest, LocaleInfo.getCurrentLocale().getLocaleName(), recaptcha)).whenComplete((registedUser, error) -> {
           if (registedUser != null) {
             if (registedUser.isActive()) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateActionJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateActionJob.java
@@ -13,6 +13,7 @@ package org.roda.wui.client.process;
 import java.util.List;
 
 import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.utils.SelectedItemsUtils;
 import org.roda.core.data.v2.index.IsIndexed;
 import org.roda.core.data.v2.index.filter.AllFilterParameter;
 import org.roda.core.data.v2.index.filter.Filter;
@@ -20,6 +21,7 @@ import org.roda.core.data.v2.index.filter.OneOfManyFilterParameter;
 import org.roda.core.data.v2.index.select.SelectedItems;
 import org.roda.core.data.v2.index.select.SelectedItemsFilter;
 import org.roda.core.data.v2.index.select.SelectedItemsList;
+import org.roda.core.data.v2.jobs.CreateJobRequest;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.PluginType;
 import org.roda.wui.client.common.LastSelectedItemsSingleton;
@@ -95,10 +97,17 @@ public class CreateActionJob extends CreateSelectedJob<IsIndexed> {
     getButtonCreate().setEnabled(false);
     String jobName = getName().getText();
 
-    Job job = JobUtils.createJob(jobName, getJobPriority(), getJobParallelism(), getSelected(),
-      getSelectedPlugin().getId(), getWorkflowOptions().getValue());
+    CreateJobRequest jobRequest = new CreateJobRequest();
+    jobRequest.setName(jobName);
+    jobRequest.setPlugin(getSelectedPlugin().getId());
+    jobRequest.setPluginParameters(getWorkflowOptions().getValue());
+    jobRequest.setSourceObjects(SelectedItemsUtils.convertToRESTRequest(getSelected()));
+    jobRequest.setPriority(getJobPriority().name());
+    jobRequest.setParallelism(getJobParallelism().name());
+    jobRequest.setSourceObjectsClass(getSelected().getSelectedClass());
+
     Services services = new Services("Create job", "create");
-    services.jobsResource(s -> s.createJob(job)).whenComplete((job1, throwable) -> {
+    services.jobsResource(s -> s.createJob(jobRequest)).whenComplete((job1, throwable) -> {
       if (throwable != null) {
         getButtonCreate().setEnabled(true);
         AsyncCallbackUtils.defaultFailureTreatment(throwable);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/JobsRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/JobsRestService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.v2.generics.StringResponse;
 import org.roda.core.data.v2.generics.select.SelectedItemsRequest;
+import org.roda.core.data.v2.jobs.CreateJobRequest;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.Jobs;
 import org.roda.core.data.v2.jobs.PluginInfo;
@@ -43,11 +44,11 @@ public interface JobsRestService extends RODAEntityRestService<Job> {
 
   @RequestMapping(method = RequestMethod.POST, path = "", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.CREATED)
-  @Operation(summary = "Create job", description = "Creates a new job", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = Job.class))), responses = {
+  @Operation(summary = "Create job", description = "Creates a new job", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CreateJobRequest.class))), responses = {
     @ApiResponse(responseCode = "201", description = "Job created successfully", content = @Content(schema = @Schema(implementation = Job.class))),
     @ApiResponse(responseCode = "409", description = "Already exists", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
   Job createJob(
-    @Parameter(name = "job", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) Job job);
+    @Parameter(name = "job", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) CreateJobRequest job);
 
   @RequestMapping(method = RequestMethod.GET, path = "/{id}/stop", produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.ACCEPTED)

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/MembersRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/MembersRestService.java
@@ -18,7 +18,9 @@ import org.roda.core.data.v2.user.requests.CreateGroupRequest;
 import org.roda.core.data.v2.user.requests.CreateUserExtraFormFields;
 import org.roda.core.data.v2.user.requests.CreateUserRequest;
 import org.roda.core.data.v2.user.requests.LoginRequest;
+import org.roda.core.data.v2.user.requests.RegisterUserRequest;
 import org.roda.core.data.v2.user.requests.ResetPasswordRequest;
+import org.roda.core.data.v2.user.requests.UpdateUserRequest;
 import org.roda.wui.api.v2.exceptions.model.ErrorResponseMessage;
 import org.roda.wui.api.v2.model.GenericOkResponse;
 import org.springframework.http.HttpStatus;
@@ -95,7 +97,7 @@ public interface MembersRestService extends RODAEntityRestService<RODAMember> {
 
   @RequestMapping(path = "/users", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.CREATED)
-  @Operation(summary = "Create user", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = User.class))), description = "Creates a new user", responses = {
+  @Operation(summary = "Create user", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CreateUserRequest.class))), description = "Creates a new user", responses = {
     @ApiResponse(responseCode = "201", description = "Created", content = @Content(schema = @Schema(implementation = User.class))),
     @ApiResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class))),
     @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
@@ -105,10 +107,10 @@ public interface MembersRestService extends RODAEntityRestService<RODAMember> {
 
   @RequestMapping(path = "/users/register", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.CREATED)
-  @Operation(summary = "Register user", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = User.class))), description = "Registers a new user", responses = {
+  @Operation(summary = "Register user", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = RegisterUserRequest.class))), description = "Registers a new user", responses = {
     @ApiResponse(responseCode = "201", description = "Created", content = @Content(schema = @Schema(implementation = User.class)))})
   User registerUser(
-    @Parameter(name = "user", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) CreateUserRequest userOperations,
+    @Parameter(name = "user", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) RegisterUserRequest userOperations,
     @Parameter(description = "The language to be used for internationalization") @RequestParam(name = "lang", defaultValue = "en", required = false) String localeString,
     @Parameter(description = "captcha") @RequestParam(required = false, name = "captcha") String captcha);
 
@@ -128,18 +130,18 @@ public interface MembersRestService extends RODAEntityRestService<RODAMember> {
     @Parameter(name = "group", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) Group modifiedGroup);
 
   @RequestMapping(path = "/users", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-  @Operation(summary = "Update user", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CreateUserRequest.class))), description = "Updates a user", responses = {
+  @Operation(summary = "Update user", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UpdateUserRequest.class))), description = "Updates a user", responses = {
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = User.class))),
     @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
   User updateUser(
-    @Parameter(name = "user", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) CreateUserRequest userOperations);
+    @Parameter(name = "user", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) UpdateUserRequest userOperations);
 
   @RequestMapping(path = "/users/update-my-user", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-  @Operation(summary = "Update my user", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CreateUserRequest.class))), description = "Updates my user", responses = {
+  @Operation(summary = "Update my user", requestBody = @RequestBody(required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UpdateUserRequest.class))), description = "Updates my user", responses = {
     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = User.class))),
     @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
   User updateMyUser(
-    @Parameter(name = "user", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) CreateUserRequest userOperations);
+    @Parameter(name = "user", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) UpdateUserRequest userOperations);
 
   @RequestMapping(path = "/users/{id}/reset-password", method = RequestMethod.PATCH)
   @ResponseStatus(HttpStatus.NO_CONTENT)


### PR DESCRIPTION
- Simplifies several API requests that required an entire object to be sent instead of only the object's relevant fields
  - Simplified user creation and register as well as job creation API requests
- Adds some missing implementations of `SelectedItemsRequest` that make it compatible with conversion to and from `SelectedItemsAll` and `SelectedItemsNone`