### PR TITLE
Fixed and changed wording of disposal confirmation deletion messages

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1439,7 +1439,7 @@ showDisposalRuleTitle:Disposal rule
 showDisposalHoldTitle:Disposal hold
 showDisposalScheduleTitle:Disposal Schedule
 applyDisposalScheduleButton:Destroy
-deleteDisposalConfirmationReport:Delete
+deleteDisposalConfirmationReport:Cancel
 permanentlyDeleteFromBinButton:Permanently delete
 reExecuteDisposalDestroyActionButton:Re-execute destruction
 recoverDisposalConfirmationExecutionFailedButton:Recover AIPs
@@ -1467,8 +1467,8 @@ disposalOnHoldStatusLabel:On hold
 disposalClearStatusLabel:Not on hold
 disposalScheduleListAips:Records with this schedule
 disposalHoldListAips:Records with this hold
-deleteConfirmationReportDialogTitle:Confirm intellectual entities destruction
-deleteConfirmationReportDialogMessage:Are you sure you want to destroy the intellectual entities?
+deleteConfirmationReportDialogTitle:Confirm disposal confirmation deletion
+deleteConfirmationReportDialogMessage:Are you sure you want to destroy the disposal confirmation?
 deleteConfirmationReportSuccessTitle:Deleting disposal confirmation
 deleteConfirmationReportSuccessMessage:Execute action to delete disposal confirmation
 disposalConfirmationDataPanelTitle:Title

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_pt_PT.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_pt_PT.properties
@@ -1403,8 +1403,8 @@ disposalOnHoldStatusLabel:Suspenso para eliminação
 disposalClearStatusLabel:Sem suspensão para eliminação
 disposalScheduleListAips:Entidades com esta tabela de seleção
 disposalHoldListAips:Entidades com esta suspensão de eliminação
-deleteConfirmationReportDialogTitle:Confirmar eliminação das entidades intelectuais
-deleteConfirmationReportDialogMessage:Tem a certeza que pretende eliminar as entidades intelectuais?
+deleteConfirmationReportDialogTitle:Confirmar eliminação do auto de eliminação
+deleteConfirmationReportDialogMessage:Tem a certeza que pretende eliminar o auto de eliminação?
 deleteConfirmationReportSuccessTitle:A apagar o auto de eliminação
 deleteConfirmationReportSuccessMessage:Executar a acção de apagar o auto de eliminação
 disposalConfirmationDataPanelTitle:Título


### PR DESCRIPTION
The wording for the deletion button and prompt for disposal confirmations was incorrect/unintuitive. Now it correctly reflects the actual action.

![image](https://github.com/user-attachments/assets/02cafd62-6853-43a1-90f3-914b3b11ef25)