### PR TITLE
Fix retrievePluginsInfo API method

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/PluginManager.java
@@ -409,11 +409,17 @@ public class PluginManager {
   }
 
   public PluginInfoList getPluginsInfo(List<PluginType> pluginTypes) {
+    return getPluginsInfo(pluginTypes, true);
+  }
+
+  public PluginInfoList getPluginsInfo(List<PluginType> pluginTypes, boolean removeNotListable) {
     PluginInfoList pluginsInfo = new PluginInfoList();
 
     for (PluginType pluginType : pluginTypes) {
-      List<PluginInfo> orDefault = pluginInfoPerType.getOrDefault(pluginType, Collections.emptyList());
-      orDefault.removeIf(p -> p.getCategories().contains(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE));
+      List<PluginInfo> orDefault = new ArrayList<>(pluginInfoPerType.getOrDefault(pluginType, Collections.emptyList()));
+      if (removeNotListable) {
+        orDefault.removeIf(p -> p.getCategories().contains(RodaConstants.PLUGIN_CATEGORY_NOT_LISTABLE));
+      }
       pluginsInfo.addObjects(orDefault);
     }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ConfigurationController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/ConfigurationController.java
@@ -123,14 +123,14 @@ public class ConfigurationController implements ConfigurationRestService {
   }
 
   @Override
-  public PluginInfoList retrievePluginsInfo(List<PluginType> types) {
+  public PluginInfoList retrievePluginsInfo(List<PluginType> types, boolean removeNotListable) {
     final ControllerAssistant controllerAssistant = new ControllerAssistant() {};
     RequestContext requestContext = RequestUtils.parseHTTPRequest(request);
     LogEntryState state = LogEntryState.SUCCESS;
     try {
       controllerAssistant.checkRoles(requestContext.getUser());
 
-      return RodaCoreFactory.getPluginManager().getPluginsInfo(types);
+      return RodaCoreFactory.getPluginManager().getPluginsInfo(types, removeNotListable);
     } catch (AuthorizationDeniedException e) {
       state = LogEntryState.UNAUTHORIZED;
       throw new RESTException(e);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/PluginParameterPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/PluginParameterPanel.java
@@ -638,7 +638,7 @@ public class PluginParameterPanel extends Composite {
   private void createPluginSipToAipLayout() {
     List<PluginType> plugins = Arrays.asList(PluginType.SIP_TO_AIP);
     Services services = new Services("Retrieve plugin information", "get");
-    services.configurationsResource(s -> s.retrievePluginsInfo(plugins)).whenComplete((pluginInfoList, throwable) -> {
+    services.configurationsResource(s -> s.retrievePluginsInfo(plugins, false)).whenComplete((pluginInfoList, throwable) -> {
       if (throwable == null) {
         Label parameterName = new Label(parameter.getName());
         layout.add(parameterName);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateDefaultJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateDefaultJob.java
@@ -202,7 +202,7 @@ public class CreateDefaultJob extends Composite {
 
     Services services = new Services("Retrieve plugin information", "get");
     pluginTypes.remove(PluginType.INTERNAL);
-    services.configurationsResource(s -> s.retrievePluginsInfo(pluginTypes))
+    services.configurationsResource(s -> s.retrievePluginsInfo(pluginTypes, true))
       .whenComplete((pluginInfoList, throwable) -> {
         if (throwable == null) {
           init(pluginInfoList.getPluginInfoList());

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateSelectedJob.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/process/CreateSelectedJob.java
@@ -182,7 +182,7 @@ public abstract class CreateSelectedJob<T extends IsIndexed> extends Composite {
     }
 
     Services services = new Services("Retrieve plugin information", "get");
-    services.configurationsResource(s -> s.retrievePluginsInfo(pluginType))
+    services.configurationsResource(s -> s.retrievePluginsInfo(pluginType, true))
       .whenComplete((pluginInfoList, throwable) -> {
         if (throwable == null) {
           init(pluginInfoList.getPluginInfoList());

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/ConfigurationRestService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/services/ConfigurationRestService.java
@@ -68,7 +68,8 @@ public interface ConfigurationRestService extends DirectRestService {
     @ApiResponse(responseCode = "200", description = "Returns a set of plugin information", content = @Content(schema = @Schema(implementation = PluginInfoList.class))),
     @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class))),
     @ApiResponse(responseCode = "403", description = "Access forbidden", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
-  PluginInfoList retrievePluginsInfo(@RequestParam(name = "type") List<PluginType> types);
+  PluginInfoList retrievePluginsInfo(@RequestParam(name = "type") List<PluginType> types,
+    @RequestParam(name = "removeNotListable", defaultValue = "true", required = false) boolean removeNotListable);
 
   @RequestMapping(method = RequestMethod.GET, path = "/plugins/reindex", produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(summary = "Retrieves a list of resources that are used by reindex plugins", responses = {


### PR DESCRIPTION
The `retrievePluginsInfo` method was inadvertently removing non-listable plugin info from the plugin manager instead of simply filtering it out from the response as intended. Additionally, some usages of the method (ingest plugin parameter layout building) did not want this plugin info to be filtered out in the first place.

- The method now clones the working list of plugin info to prevent erasing data from the plugin manager's own list
- The method now receives an optional flag indicating whether not-listable plugins will be filtered from the response (default behavior is to filter)