### PR TITLE
 Support for translations in disposal rules order panel (RODA 5)

### DIFF
--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -2138,6 +2138,14 @@ public interface ClientMessages extends Messages {
 
   String editRulesOrder();
 
+  String editRulesOrderTop();
+
+  String editRulesOrderUp();
+
+  String editRulesOrderDown();
+
+  String editRulesOrderBottom();
+
   String confirmChangeRulesOrder();
 
   String deleteDisposalRuleDialogTitle();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/OrderDisposalRules.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/disposal/rule/OrderDisposalRules.java
@@ -125,7 +125,7 @@ public class OrderDisposalRules extends Composite {
 
   private void createTopButton() {
     Button buttonTop = new Button();
-    buttonTop.setText("top");
+    buttonTop.setText(messages.editRulesOrderTop());
     buttonTop.addStyleName("btn btn-block btn-default btn-top");
     buttonTop.addClickHandler(clickEvent -> {
       if (selectedRule != null && selectedIndex != 0) {
@@ -141,7 +141,7 @@ public class OrderDisposalRules extends Composite {
 
   private void createUpButton() {
     Button buttonUp = new Button();
-    buttonUp.setText("up");
+    buttonUp.setText(messages.editRulesOrderUp());
     buttonUp.addStyleName("btn btn-block btn-default btn-up");
     buttonUp.addClickHandler(clickEvent -> {
       int previousIndex = selectedIndex - 1;
@@ -159,7 +159,7 @@ public class OrderDisposalRules extends Composite {
 
   private void createDownButton() {
     Button buttonDown = new Button();
-    buttonDown.setText("down");
+    buttonDown.setText(messages.editRulesOrderDown());
     buttonDown.addStyleName("btn btn-block btn-default btn-down");
     buttonDown.addClickHandler(clickEvent -> {
       int nextIndex = selectedIndex + 1;
@@ -177,7 +177,7 @@ public class OrderDisposalRules extends Composite {
 
   private void createBottomButton() {
     Button buttonBottom = new Button();
-    buttonBottom.setText("bottom");
+    buttonBottom.setText(messages.editRulesOrderBottom());
     buttonBottom.addStyleName("btn btn-block btn-default btn-bottom");
     buttonBottom.addClickHandler(clickEvent -> {
       int lastIndex = disposalRules.getObjects().size() - 1;

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -1490,6 +1490,10 @@ disposalRulePreviewButtonText:Preview
 disposalTitle:Disposal
 conditionActualParent:Actual parent
 editRulesOrder:Edit rules order
+editRulesOrderTop:Top
+editRulesOrderUp:Up
+editRulesOrderDown:Down
+editRulesOrderBottom:Bottom
 confirmChangeRulesOrder:Are you sure you want to change the order of the disposal rules?
 deleteDisposalRuleDialogTitle:Remove disposal rule
 deleteDisposalRuleDialogMessage:Are you sure you want to remove the disposal rule {0}?

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_pt_PT.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages_pt_PT.properties
@@ -1426,6 +1426,10 @@ disposalRulePreviewButtonText:Pré-visualização
 disposalTitle:Eliminação
 conditionActualParent:Pai atual
 editRulesOrder:Ordenar condições
+editRulesOrderTop:Topo
+editRulesOrderUp:Cima
+editRulesOrderDown:Baixo
+editRulesOrderBottom:Fundo
 confirmChangeRulesOrder:Tem a certeza que prentende alterar a ordem das condições de eliminação?
 deleteDisposalRuleDialogTitle:Remover condição de eliminação
 deleteDisposalRuleDialogMessage:Tem a certeza que pretende remover a condição de eliminação {0}?


### PR DESCRIPTION
Made hard coded strings in disposal rules order panel buttons into translated messages