### PR TITLE
Align button icons

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -7897,7 +7897,7 @@ span.code {
     position: relative;
     white-space: nowrap;
     width: 100%;
-    align-items: flex-start;
+    align-items: center;
     box-sizing: border-box;
     text-rendering: auto;
     letter-spacing: normal;


### PR DESCRIPTION
Makes buttons align their items with `align-items: center` rather than `flex-start`, which improves alignment in firefox
<img width="250" height="119" alt="image" src="https://github.com/user-attachments/assets/8b6bad05-ced6-484b-8dac-9b1432af51b0" />
