### PR TITLE
Fixed truncated iframe in BitstreamPreview

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BitstreamPreview.java
@@ -388,7 +388,11 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
     final Frame frame = new Frame(url);
     frame.setStyleName("viewDIPPreview");
     frame.setTitle(dip.getTitle());
-    frame.addLoadHandler(ev -> JavascriptUtils.runIframeResizer(frame.getElement()));
+    frame.getElement().setAttribute("scrolling", "auto");
+
+    if(isSameOrigin(url)){
+        frame.addLoadHandler(ev -> JavascriptUtils.runIframeResizer(frame.getElement()));
+    }
     panel.add(frame);
   }
 
@@ -534,5 +538,10 @@ public class BitstreamPreview<T extends IsIndexed> extends Composite {
       }
     }
     return false;
+  }
+
+  public boolean isSameOrigin(String url){
+      String base = GWT.getHostPageBaseURL();
+      return url !=null && base != null && url.startsWith(base);
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -5432,7 +5432,8 @@ td.datePickerMonth, td.datePickerYear {
 
 .viewRepresentationHtmlFilePreview, .viewDIPPreview {
     width: 100%;
-    height: 670px;
+    height: 80vh;
+    min-height: 480px;
 }
 
 .viewRepresentationTextFilePreview {


### PR DESCRIPTION
- Replaced heigh attributes in main.gss for .viewDIPPreview with responsive height and a minimal height
- Allowed native scrolling in iframe element
- Run iframe resizer only in same origin URLs to avoid injected overflow:hidden on other origin iframe urls with isSameOrigin method

Fixes #3523 