### PR TITLE
v2 API & UI cleanup: preview/download split, fixed downloads (Files and DIPFiles), toolbar updates 

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -401,6 +401,9 @@ public final class RodaConstants {
   // dips
   public static final String API_REST_V2_DIPS = "api/v2/dips/";
 
+  // dipfiles
+  public static final String API_REST_V2_DIPFILES = "api/v2/dip-files/";
+
   // representation-information
   public static final String API_REST_V2_REPRESENTATION_INFORMATION = "api/v2/representation-information/";
 

--- a/roda-core/roda-core/src/main/resources/config/roda-roles.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-roles.properties
@@ -252,6 +252,10 @@ core.roles.org.roda.wui.api.v2.controller.DIPController.deleteIndexedDIPs = aip.
 core.roles.org.roda.wui.api.v2.controller.DIPController.downloadBinary = aip.read
 core.roles.org.roda.wui.api.v2.controller.DIPController.updatePermissions = aip.update
 
+# DIPFile roles
+core.roles.org.roda.wui.api.v2.controller.DIPFileController.previewBinary = aip.read
+core.roles.org.roda.wui.api.v2.controller.DIPFileController.downloadBinary = aip.read
+
 # Configuration roles
 core.roles.org.roda.wui.api.v2.controller.ConfigurationController.retrievePluginsInfo = job.read
 core.roles.org.roda.wui.api.v2.controller.ConfigurationController.retrieveReindexPluginObjectClasses = job.read

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPController.java
@@ -107,10 +107,8 @@ public class DIPController implements DIPRestService, Exportable {
       public ResponseEntity<StreamingResponseBody> process(RequestContext requestContext,
         RequestControllerAssistant controllerAssistant) throws RODAException, RESTException {
 
-        IndexedDIP dip = indexService.retrieve(IndexedDIP.class, dipUUID, new ArrayList<>());
-
+        IndexedDIP dip = requestContext.getIndexService().retrieve(IndexedDIP.class, dipUUID, new ArrayList<>());
         controllerAssistant.checkObjectPermissions(requestContext.getUser(), dip);
-
         controllerAssistant.setParameters(RodaConstants.CONTROLLER_DIP_UUID_PARAM, dipUUID);
 
         return ApiUtils.okResponse(dipService.createStreamResponse(requestContext, dip.getUUID()));

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPFileController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/DIPFileController.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.exceptions.RODAException;
 import org.roda.core.data.v2.generics.LongResponse;
 import org.roda.core.data.v2.index.CountRequest;
 import org.roda.core.data.v2.index.FindRequest;
@@ -18,18 +19,32 @@ import org.roda.core.data.v2.index.IndexResult;
 import org.roda.core.data.v2.index.SuggestRequest;
 import org.roda.core.data.v2.ip.DIPFile;
 import org.roda.core.model.utils.UserUtility;
+import org.roda.wui.api.v2.exceptions.RESTException;
+import org.roda.wui.api.v2.exceptions.model.ErrorResponseMessage;
+import org.roda.wui.api.v2.services.DIPFileService;
 import org.roda.wui.api.v2.services.IndexService;
 import org.roda.wui.api.v2.utils.ApiUtils;
 import org.roda.wui.client.services.DIPFileRestService;
+import org.roda.wui.common.RequestControllerAssistant;
 import org.roda.wui.common.model.RequestContext;
 import org.roda.wui.common.utils.RequestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 
 /**
@@ -43,6 +58,12 @@ public class DIPFileController implements DIPFileRestService, Exportable {
 
   @Autowired
   IndexService indexService;
+
+  @Autowired
+  DIPFileService dipFileService;
+
+  @Autowired
+  RequestHandler requestHandler;
 
   @Override
   public DIPFile findByUuid(String uuid, String localeString) {
@@ -74,5 +95,42 @@ public class DIPFileController implements DIPFileRestService, Exportable {
   public ResponseEntity<StreamingResponseBody> exportToCSV(String findRequestString) {
     // delegate
     return ApiUtils.okResponse(indexService.exportToCSV(findRequestString, DIPFile.class));
+  }
+
+  @GetMapping(path = "{uuid}/preview", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+  @Operation(summary = "DIP file View", description = "View DIP file binary", responses = {
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = StreamingResponseBody.class))),
+    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class))),
+    @ApiResponse(responseCode = "404", description = "DIP file not found", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
+  public ResponseEntity<StreamingResponseBody> previewBinary(
+    @Parameter(description = "The UUID of the existing DIP file", required = true) @PathVariable(name = "uuid") String dipFileUUID,
+    @RequestHeader HttpHeaders headers) {
+    return requestHandler.processRequest(new RequestHandler.RequestProcessor<ResponseEntity<StreamingResponseBody>>() {
+      @Override
+      public ResponseEntity<StreamingResponseBody> process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant) throws RODAException, RESTException {
+        List<String> dipPermissionFields = new ArrayList<>(RodaConstants.DIPFILE_FIELDS_TO_RETURN);
+        DIPFile dipFile = requestContext.getIndexService().retrieve(DIPFile.class, dipFileUUID, dipPermissionFields);
+        return ApiUtils.rangeResponse(headers, dipFileService.retrieveDIPFileRangeStream(requestContext, dipFile));
+      }
+    });
+  }
+
+  @GetMapping(path = "{uuid}/download", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+  @Operation(summary = "DIP file Preview", description = "Preview the DIP file binary", responses = {
+    @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = StreamingResponseBody.class))),
+    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class))),
+    @ApiResponse(responseCode = "404", description = "DIP file not found", content = @Content(schema = @Schema(implementation = ErrorResponseMessage.class)))})
+  public ResponseEntity<StreamingResponseBody> downloadBinary(@PathVariable(name = "uuid") String dipFileUUID) {
+
+    return requestHandler.processRequest(new RequestHandler.RequestProcessor<ResponseEntity<StreamingResponseBody>>() {
+      @Override
+      public ResponseEntity<StreamingResponseBody> process(RequestContext requestContext,
+        RequestControllerAssistant controllerAssistant) throws RODAException, RESTException {
+        List<String> fileFields = new ArrayList<>(RodaConstants.DIPFILE_FIELDS_TO_RETURN);
+        DIPFile dipFile = requestContext.getIndexService().retrieve(DIPFile.class, dipFileUUID, fileFields);
+        return ApiUtils.okResponse(dipFileService.retrieveDIPFileStreamResponse(requestContext, dipFile));
+      }
+    });
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DIPFileService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DIPFileService.java
@@ -1,0 +1,60 @@
+package org.roda.wui.api.v2.services;
+
+import org.roda.core.data.exceptions.AuthorizationDeniedException;
+import org.roda.core.data.exceptions.GenericException;
+import org.roda.core.data.exceptions.NotFoundException;
+import org.roda.core.data.exceptions.RequestNotValidException;
+import org.roda.core.data.v2.ConsumesOutputStream;
+import org.roda.core.data.v2.LiteRODAObject;
+import org.roda.core.data.v2.StreamResponse;
+import org.roda.core.data.v2.ip.DIPFile;
+import org.roda.core.model.LiteRODAObjectFactory;
+import org.roda.core.model.ModelService;
+import org.roda.core.storage.DirectResourceAccess;
+import org.roda.core.storage.RangeConsumesOutputStream;
+import org.roda.wui.common.model.RequestContext;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ *
+ * @author Eduardo Teixeira <eteixeira@keep.pt>
+ */
+@Service
+public class DIPFileService {
+  public RangeConsumesOutputStream retrieveDIPFileRangeStream(RequestContext requestContext, DIPFile dipfile)
+    throws RequestNotValidException {
+    ModelService model = requestContext.getModelService();
+    if (!dipfile.isDirectory()) {
+      final RangeConsumesOutputStream stream;
+      try {
+        DirectResourceAccess directDIPFileAccess = model.getDirectAccess(dipfile);
+        stream = new RangeConsumesOutputStream(directDIPFileAccess.getPath());
+        return stream;
+      } catch (RequestNotValidException | GenericException | AuthorizationDeniedException | NotFoundException e) {
+        throw new RuntimeException(e);
+      }
+
+    } else
+      throw new RequestNotValidException("Range stream for directory unsupported");
+  }
+
+  public StreamResponse retrieveDIPFileStreamResponse(RequestContext requestContext, DIPFile dipFile)
+    throws GenericException, RequestNotValidException, NotFoundException, AuthorizationDeniedException {
+    ModelService model = requestContext.getModelService();
+
+    final ConsumesOutputStream stream;
+    List<String> idPaths = new ArrayList<>();
+    idPaths.add(dipFile.getDipId());
+    idPaths.addAll(dipFile.getPath());
+    idPaths.add(dipFile.getId());
+
+    Optional<LiteRODAObject> rodaDIPobj = LiteRODAObjectFactory.get(DIPFile.class, idPaths.toArray(String[]::new));
+    stream = model.exportObjectToStream(rodaDIPobj.get());
+    return new StreamResponse(stream);
+
+  }
+}

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
@@ -247,7 +247,13 @@ public class FilesService {
   public StreamResponse retrieveAIPRepresentationFile(RequestContext requestContext, IndexedFile indexedFile)
     throws GenericException, RequestNotValidException, NotFoundException, AuthorizationDeniedException {
     ModelService model = requestContext.getModelService();
-    Optional<LiteRODAObject> liteFile = LiteRODAObjectFactory.get(File.class, indexedFile.getId());
+    List<String> ids = new ArrayList<>();
+    ids.add(indexedFile.getAipId());
+    ids.add(indexedFile.getRepresentationId());
+    ids.addAll(indexedFile.getPath());
+    ids.add(indexedFile.getId());
+    Optional<LiteRODAObject> liteFile = LiteRODAObjectFactory.get(File.class, ids.toArray(String[]::new));
+
     if (liteFile.isEmpty()) {
       throw new RequestNotValidException("Couldn't retrieve file with id: " + indexedFile.getId());
     }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseDIP.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/BrowseDIP.ui.xml
@@ -10,7 +10,7 @@
     <wcag:AccessibleFocusPanel ui:field="keyboardFocus">
         <g:FlowPanel styleName="viewRepresentationFile" ui:field="container">
             <common:NavigationToolbar ui:field="navigationToolbar"/>
-            <common:BrowseDIPActionsToolbar ui:field="objectToolbar" label="{messages.catalogueDIPTitle}"/>
+            <common:ActionsToolbar ui:field="objectToolbar" label="{messages.catalogueDIPTitle}"/>
             <!-- top navigation toolbar for referrer is inserted here  -->
             <!-- bottom navigation toolbar for dipfile or dip is inserted here -->
             <g:FlowPanel addStyleNames="row full_width skip_padding">

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DipFilePreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/DipFilePreview.java
@@ -19,7 +19,6 @@ import org.roda.wui.client.common.search.SearchWrapper;
 import org.roda.wui.common.client.tools.RestUtils;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
@@ -32,13 +31,8 @@ public class DipFilePreview extends BitstreamPreview<DIPFile> {
   private static final ClientMessages messages = GWT.create(ClientMessages.class);
 
   public DipFilePreview(Viewers viewers, DIPFile dipFile) {
-    super(viewers, RestUtils.createDipFileDownloadUri(dipFile.getUUID(), CONTENT_DISPOSITION_INLINE), NO_FORMAT,
+    super(viewers, RestUtils.createDipFilePreviewUri(dipFile.getUUID(), CONTENT_DISPOSITION_INLINE), NO_FORMAT,
       dipFile.getId(), dipFile.getSize(), dipFile.isDirectory(), dipFile);
-  }
-
-  public DipFilePreview(Viewers viewers, DIPFile dipFile, Command onPreviewFailure) {
-    super(viewers, RestUtils.createDipFileDownloadUri(dipFile.getUUID(), CONTENT_DISPOSITION_INLINE), NO_FORMAT,
-      dipFile.getId(), dipFile.getSize(), dipFile.isDirectory(), onPreviewFailure, dipFile);
   }
 
   @Override

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/IndexedFilePreview.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/IndexedFilePreview.java
@@ -40,7 +40,7 @@ public class IndexedFilePreview extends BitstreamPreview<IndexedFile> {
 
   public IndexedFilePreview(Viewers viewers, IndexedFile file, boolean isAvailable, boolean justActive, AIPState state,
     Permissions permissions, Command onPreviewFailure) {
-    super(viewers, RestUtils.createRepresentationFileDownloadUri(file.getUUID(), CONTENT_DISPOSITION_INLINE),
+    super(viewers, RestUtils.createRepresentationFilePreviewUri(file.getUUID(), CONTENT_DISPOSITION_INLINE),
       file.getFileFormat(), file.getOriginalName() != null ? file.getOriginalName() : file.getId(), file.getSize(),
       file.isDirectory(), isAvailable, onPreviewFailure, file, justActive, state, permissions);
   }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseDIPTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseDIPTabs.java
@@ -47,7 +47,7 @@ public class BrowseDIPTabs extends Tabs {
     DIPFile dipFile = browseDIPResponse.getDipFile();
 
     // DIPFile preview
-    createAndAddTab(SafeHtmlUtils.fromSafeConstant(messages.descriptiveMetadataTab()), new TabContentBuilder() {
+    createAndAddTab(SafeHtmlUtils.fromSafeConstant(messages.viewTab()), new TabContentBuilder() {
       @Override
       public Widget buildTabWidget() {
         if (dipFile != null) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseDIPFileActionsToolbar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseDIPFileActionsToolbar.java
@@ -1,0 +1,36 @@
+package org.roda.wui.client.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.v2.ip.DIPFile;
+import org.roda.wui.client.common.actions.DisseminationFileActions;
+import org.roda.wui.client.common.actions.model.ActionableObject;
+import org.roda.wui.client.common.actions.widgets.ActionableWidgetBuilder;
+import org.roda.wui.common.client.tools.ConfigurationManager;
+
+/**
+ *
+ * @author Eduardo Teixeira <eteixeira@keep.pt>
+ */
+public class BrowseDIPFileActionsToolbar extends BrowseObjectActionsToolbar<DIPFile> {
+  public void buildIcon() {
+    setIcon(ConfigurationManager.getString(RodaConstants.UI_ICONS_CLASS, DIPFile.class.getSimpleName()));
+  }
+
+  public void buildTags() {
+    // do nothing
+  }
+
+  public void buildActions() {
+    this.actions.clear();
+    // AIP actions
+    DisseminationFileActions dipFileActions;
+    dipFileActions = DisseminationFileActions.get(actionPermissions);
+    this.actions.add(new ActionableWidgetBuilder<DIPFile>(dipFileActions).withActionCallback(actionCallback)
+      .buildGroupedListWithObjects(new ActionableObject<>(object), new ArrayList<>(),
+        List.of(DisseminationFileActions.DisseminationFileAction.DOWNLOAD)));
+
+  }
+}

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/RestUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/RestUtils.java
@@ -84,16 +84,20 @@ public class RestUtils {
     return UriUtils.fromSafeConstant(b.toString());
   }
 
-  public static SafeUri createRepresentationFileDownloadUri(String fileUuid) {
-    return createRepresentationFileDownloadUri(fileUuid, false);
-  }
-
-  public static SafeUri createRepresentationFileDownloadUri(String fileUuid, boolean contentDispositionInline) {
+    public static SafeUri createRepresentationFilePreviewUri(String fileUuid, boolean contentDispositionInline) {
     // api/v2/files/{file_uuid}/preview
     String b = RodaConstants.API_REST_V2_FILES + URL.encodeQueryString(fileUuid)
       + RodaConstants.API_REST_V2_PREVIEW_HANDLER;
 
     return UriUtils.fromSafeConstant(b);
+  }
+
+  public static SafeUri createRepresentationFileDownloadUri(String fileUuid){
+      // api/v2/files/{file_uuid}/download
+      StringBuilder b = new StringBuilder();
+      b.append(RodaConstants.API_REST_V2_FILES).append(URL.encodeQueryString(fileUuid)).append(RodaConstants.API_REST_V2_DOWNLOAD_HANDLER);
+
+      return UriUtils.fromSafeConstant(b.toString());
   }
 
   public static SafeUri createDipDownloadUri(String dipUUID) {
@@ -105,23 +109,22 @@ public class RestUtils {
     return UriUtils.fromSafeConstant(b.toString());
   }
 
-  public static SafeUri createDipFileDownloadUri(String dipFileUUID) {
-    return createDipFileDownloadUri(dipFileUUID, false);
-  }
-
-  public static SafeUri createDipFileDownloadUri(String dipFileUUID, boolean contentDispositionInline) {
-
-    // api/v1/dipfiles/{file_uuid}?acceptFormat=bin&inline={inline}
+  public static SafeUri createDipFilePreviewUri(String dipFileUUID, boolean contentDispositionInline) {
+    // api/v2/dip-files/{file_uuid}/preview?inline={inline}
     StringBuilder b = new StringBuilder();
     // base uri
-    b.append(RodaConstants.API_REST_V1_DIPFILES).append(URL.encodeQueryString(dipFileUUID));
-    // accept format attribute
-    b.append(RodaConstants.API_QUERY_START).append(RodaConstants.API_QUERY_KEY_ACCEPT_FORMAT)
-      .append(RodaConstants.API_QUERY_ASSIGN_SYMBOL).append(RodaConstants.API_QUERY_VALUE_ACCEPT_FORMAT_BIN);
+    b.append(RodaConstants.API_REST_V2_DIPFILES).append(URL.encodeQueryString(dipFileUUID))
+      .append(RodaConstants.API_REST_V2_PREVIEW_HANDLER).append(RodaConstants.API_QUERY_START)
+      .append(RodaConstants.API_QUERY_KEY_INLINE).append(RodaConstants.API_QUERY_ASSIGN_SYMBOL)
+      .append(contentDispositionInline);
+    return UriUtils.fromSafeConstant(b.toString());
+  }
 
-    b.append(RodaConstants.API_QUERY_SEP).append(RodaConstants.API_QUERY_KEY_INLINE)
-      .append(RodaConstants.API_QUERY_ASSIGN_SYMBOL).append(contentDispositionInline);
-
+  public static SafeUri createDipFileDownloadUri(String dipFileUUID){
+    // api/v2/dip-files/{file_uuid}/download
+    StringBuilder b = new StringBuilder();
+    b.append(RodaConstants.API_REST_V2_DIPFILES).append(URL.encodeQueryString(dipFileUUID))
+      .append(RodaConstants.API_REST_V2_DOWNLOAD_HANDLER);
     return UriUtils.fromSafeConstant(b.toString());
   }
 


### PR DESCRIPTION
fixed broken downloads and filled missing v2 API endpoints by cleanly separating preview vs download for Files and DIPFiles. It updated controllers/services, aligned UI helpers with the new endpoints, and introduced a dynamic toolbar in order to assign the correct actions. Fixes #3516 

## RodaConstants
added API_REST_V2_DIPFILES constant for the new DIPFiles endpoints.

## DIPController
fixed /api/v2/dips/{uuid}/download to use requestContext.getIndexService() (correct index access) and streamed the response.

## DIPFileController and DIPFileService
added v2 endpoints:

- GET /api/v2/dip-files/{uuid}/preview — range preview of a DIPFile (retrieveDIPFileRangeStream)
- GET /api/v2/dip-files/{uuid}/download — export/stream a DIPFile (retrieveDIPFileStreamResponse)

## roda-roles.properties
added new roda-roles properties permissions for DIPFileController endpoint methods previewBinary and downloadBinary (aip.read)

## FilesService
fixed representation file download by building the full path from IndexedFile metadata and using it to resolve (stream file vs export directory if folder)

## BrowseDIP
replaced @UIField BrowseDIPActionsToolbar with provided ActionsToolbar for dynamic toolbar
created a new **BrowseDIPFileActionsToolbar.java** class specific for download, uses DisseminationFileActions.java
updated BrowseDIP.ui.xml with ActionsToolbar binding

## BrowseDIPTabs
fixed view tab for dissemination preview

## RestUtils
### Files (representation files):
- added createRepresentationFilePreviewUri(String fileUuid, boolean inline) → built GET /api/v2/files/{uuid}/preview (inline preview; HTTP Range–friendly).
- added createRepresentationFileDownloadUri(String fileUuid) → built GET /api/v2/files/{uuid}/download (explicit download).

### DIPFiles:
- added createDipFilePreviewUri(String dipFileUUID, boolean inline) → built GET /api/v2/dip-files/{uuid}/preview?inline={inline} (inline preview; range-enabled).
- added createDipFileDownloadUri(String dipFileUUID) → built GET /api/v2/dip-files/{uuid}/download (explicit download/export).

## DipFilePreview 
switched preview source to /api/v2/dip-files/{uuid}/preview via RestUtils.createDipFilePreviewUri (was using download).
removed unused constructor and minor cleanup.

## IndexedFilePreview
Use RestUtils.createRepresentationFilePreviewUri instead of download helper.