### PR TITLE
Fix technical metadata URN and Solr indexing inconsistencies

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/URNUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/URNUtils.java
@@ -51,7 +51,7 @@ public final class URNUtils {
   }
 
   public static String createRodaTechnicalMetadataURN(String id, String instanceId, String technicalMetadataType) {
-    return getTechnicalMetadataPrefix(technicalMetadataType, instanceId) + id;
+    return getTechnicalMetadataPrefix(technicalMetadataType, instanceId) + id + RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION;
   }
 
   public static String getTechnicalMetadataPrefix(String technicalMetadataType, String instanceId) {

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
@@ -1545,7 +1545,7 @@ public class SolrUtils {
 
       StoragePath storagePath = ModelUtils.getTechnicalMetadataStoragePath(techMd.getAipId(),
         techMd.getRepresentationId(), Collections.singletonList(techMd.getType()),
-        urn + RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION);
+        urn);
 
       Binary binary = model.getStorage().getBinary(storagePath);
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
@@ -398,12 +398,12 @@ public class FilesService {
     if (versionID != null) {
       BinaryVersion binaryVersion = model.getBinaryVersion(representation, versionID,
         List.of(RodaConstants.STORAGE_DIRECTORY_METADATA, RodaConstants.STORAGE_DIRECTORY_TECHNICAL, type,
-          techMDURN + RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION));
+          techMDURN));
       metadataBinary = binaryVersion.getBinary();
     } else {
       metadataBinary = model.getBinary(representation, RodaConstants.STORAGE_DIRECTORY_METADATA,
         RodaConstants.STORAGE_DIRECTORY_TECHNICAL, type,
-        techMDURN + RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION);
+        techMDURN);
     }
     String filename = metadataBinary.getStoragePath().getName() + HTML_EXT;
     String htmlDescriptive = HTMLUtils.technicalMetadataToHtml(metadataBinary, type, versionID,
@@ -433,12 +433,12 @@ public class FilesService {
     if (versionID != null) {
       BinaryVersion binaryVersion = model.getBinaryVersion(representation, versionID,
         List.of(RodaConstants.STORAGE_DIRECTORY_METADATA, RodaConstants.STORAGE_DIRECTORY_TECHNICAL, type,
-          techMDURN + RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION));
+          techMDURN));
       metadataBinary = binaryVersion.getBinary();
     } else {
       metadataBinary = model.getBinary(representation, RodaConstants.STORAGE_DIRECTORY_METADATA,
         RodaConstants.STORAGE_DIRECTORY_TECHNICAL, type,
-        techMDURN + RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION);
+        techMDURN);
     }
     stream = new BinaryConsumesOutputStream(metadataBinary, RodaConstants.MEDIA_TYPE_TEXT_XML);
 


### PR DESCRIPTION
- ensure technical metadata URNs include the correct file extension, `createRodaTechnicalMetadataURN` no longer returns only the prefix and identifier, but also concatenates the constant `REPRESENTATION_INFORMATION_FILE_EXTENSION`
- prevent double-extension issues during Solr indexing by using the full URN in `indexRepresentationTechnicalMetadata`
- extension is no longer manually appended to the URN when searching for the file in FilesService

Related to #3521