### PR TITLE
Fix technical metadata URN, File collision and Solr indexing inconsistencies

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/URNUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/URNUtils.java
@@ -51,7 +51,7 @@ public final class URNUtils {
   }
 
   public static String createRodaTechnicalMetadataURN(String id, String instanceId, String technicalMetadataType) {
-    return getTechnicalMetadataPrefix(technicalMetadataType, instanceId) + id;
+    return getTechnicalMetadataPrefix(technicalMetadataType, instanceId) + id + RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION;
   }
 
   public static String getTechnicalMetadataPrefix(String technicalMetadataType, String instanceId) {

--- a/roda-common/roda-common-utils/src/main/java/org/roda/core/util/IdUtils.java
+++ b/roda-common/roda-common-utils/src/main/java/org/roda/core/util/IdUtils.java
@@ -191,6 +191,12 @@ public final class IdUtils {
     return getTransferredResourceUUID(relativeToBase.toString());
   }
 
+  public static String createTechnicalMetadataFileId(String fileId, List<String> fileDirectoryPath){
+    if(fileDirectoryPath.isEmpty()) return fileId;
+    String pathPrefix = String.join(ID_SEPARATOR, fileDirectoryPath);
+    return pathPrefix + ID_SEPARATOR + fileId;
+  }
+
   public static String getTransferredResourceUUID(String relativeToBase) {
     return IdUtils.createUUID(relativeToBase);
   }

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/FileCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/FileCollection.java
@@ -195,8 +195,11 @@ public class FileCollection extends AbstractSolrCollection<IndexedFile, File> {
 
     Long sizeInBytes = 0L;
 
-    SolrUtils.indexRepresentationTechnicalMetadata(model,
-      getRepresentationTechnicalMetadata(((Info) info).aip, file.getRepresentationId()), fileId, doc);
+    if (!file.isDirectory()) {
+      String techMdFileId = IdUtils.createTechnicalMetadataFileId(fileId, file.getPath());
+      SolrUtils.indexRepresentationTechnicalMetadata(model,
+        getRepresentationTechnicalMetadata(((Info) info).aip, file.getRepresentationId()), techMdFileId, doc);
+    }
 
     // Add information from PREMIS
     Binary premisFile = getFilePremisFile(model, file);

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/utils/SolrUtils.java
@@ -1545,7 +1545,7 @@ public class SolrUtils {
 
       StoragePath storagePath = ModelUtils.getTechnicalMetadataStoragePath(techMd.getAipId(),
         techMd.getRepresentationId(), Collections.singletonList(techMd.getType()),
-        urn + RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION);
+        urn);
 
       Binary binary = model.getStorage().getBinary(storagePath);
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultTransactionalModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultTransactionalModelService.java
@@ -440,6 +440,23 @@ public class DefaultTransactionalModelService implements TransactionalModelServi
   }
 
   @Override
+  public Binary retrieveTechnicalMetadataBinary(String aipId, String representationId, List<String> fileDirectoryPath,
+    String fileId) throws AuthorizationDeniedException, RequestNotValidException, NotFoundException, GenericException {
+    List<TransactionalModelOperationLog> operationLogs = operationRegistry.registerOperationForTechnicalMetadata(aipId,
+      representationId, fileDirectoryPath, fileId, OperationType.READ);
+
+    try {
+      Binary binary = stagingModelService.retrieveTechnicalMetadataBinary(aipId, representationId, fileDirectoryPath,
+        fileId);
+      operationRegistry.updateOperationState(operationLogs, OperationState.SUCCESS);
+      return binary;
+    } catch (RequestNotValidException | GenericException | NotFoundException | AuthorizationDeniedException e) {
+      operationRegistry.updateOperationState(operationLogs, OperationState.FAILURE);
+      throw e;
+    }
+  }
+
+  @Override
   public DescriptiveMetadata retrieveDescriptiveMetadata(String aipId, String descriptiveMetadataId)
     throws RequestNotValidException, GenericException, NotFoundException, AuthorizationDeniedException {
     List<TransactionalModelOperationLog> operationLogs = operationRegistry
@@ -1482,6 +1499,23 @@ public class DefaultTransactionalModelService implements TransactionalModelServi
       representationId, OperationType.CREATE);
     try {
       getModelService().createTechnicalMetadata(aipId, representationId, metadataType, fileId, payload, createdBy,
+        notify);
+      operationRegistry.updateOperationState(operationLogs, OperationState.SUCCESS);
+    } catch (AuthorizationDeniedException | RequestNotValidException | AlreadyExistsException | NotFoundException
+      | GenericException e) {
+      operationRegistry.updateOperationState(operationLogs, OperationState.FAILURE);
+      throw e;
+    }
+  }
+
+  @Override
+  public void updateTechnicalMetadata(String aipId, String representationId, String metadataType, String fileId,
+    ContentPayload payload, String createdBy, boolean notify) throws AuthorizationDeniedException,
+    RequestNotValidException, AlreadyExistsException, NotFoundException, GenericException {
+    List<TransactionalModelOperationLog> operationLogs = operationRegistry.registerOperationForRepresentation(aipId,
+      representationId, OperationType.UPDATE);
+    try {
+      getModelService().updateTechnicalMetadata(aipId, representationId, metadataType, fileId, payload, createdBy,
         notify);
       operationRegistry.updateOperationState(operationLogs, OperationState.SUCCESS);
     } catch (AuthorizationDeniedException | RequestNotValidException | AlreadyExistsException | NotFoundException

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/LiteRODAObjectFactory.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/LiteRODAObjectFactory.java
@@ -42,6 +42,7 @@ import org.roda.core.data.v2.ip.metadata.IndexedPreservationEvent;
 import org.roda.core.data.v2.ip.metadata.OtherMetadata;
 import org.roda.core.data.v2.ip.metadata.PreservationMetadata;
 import org.roda.core.data.v2.ip.metadata.PreservationMetadata.PreservationMetadataType;
+import org.roda.core.data.v2.ip.metadata.TechnicalMetadata;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.Report;
 import org.roda.core.data.v2.log.LogEntry;
@@ -162,6 +163,8 @@ public final class LiteRODAObjectFactory {
       ret = getOtherMetadata(object);
     } else if (object instanceof PreservationMetadata) {
       ret = getPreservationMetadata(object);
+    } else if (object instanceof TechnicalMetadata) {
+      ret = getTechnicalMetadata(object);
     } else if (object instanceof IndexedPreservationEvent) {
       ret = getIndexedPreservationEvent(object);
     } else if (object instanceof DIPFile) {
@@ -215,6 +218,10 @@ public final class LiteRODAObjectFactory {
       if (ids.size() == 2 || ids.size() == 3) {
         ret = create(objectClass, ids.size(), ids);
       }
+    } else if (objectClass == TechnicalMetadata.class) {
+      if (ids.size() >= 3) {
+        ret = create(objectClass, ids.size(), ids);
+      }
     } else if (objectClass == OtherMetadata.class) {
       if (ids.size() == 2 || ids.size() == 3) {
         ret = create(objectClass, ids.size(), ids);
@@ -263,6 +270,16 @@ public final class LiteRODAObjectFactory {
     }
 
     return ret;
+  }
+
+  private static <T extends IsRODAObject> Optional<LiteRODAObject> getTechnicalMetadata(T object) {
+    Optional<LiteRODAObject> ret;
+    TechnicalMetadata o = (TechnicalMetadata) object;
+    List<String> list = new ArrayList<>();
+    list.add(o.getAipId());
+    list.add(o.getRepresentationId());
+    list.add(o.getId());
+    return get(TechnicalMetadata.class, list, false);
   }
 
   private static <T extends IsRODAObject> Optional<LiteRODAObject> getOtherMetadata(T object) {

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/ModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/ModelService.java
@@ -164,6 +164,9 @@ public interface ModelService extends ModelObservable {
   Binary retrieveDescriptiveMetadataBinary(String aipId, String representationId, String descriptiveMetadataId)
     throws RequestNotValidException, GenericException, NotFoundException, AuthorizationDeniedException;
 
+  Binary retrieveTechnicalMetadataBinary(String aipId, String representationId, List<String> fileDirectoryPath, String fileId)
+    throws RequestNotValidException, GenericException, NotFoundException, AuthorizationDeniedException ;
+
   DescriptiveMetadata retrieveDescriptiveMetadata(String aipId, String descriptiveMetadataId)
     throws RequestNotValidException, GenericException, NotFoundException, AuthorizationDeniedException;
 
@@ -379,6 +382,10 @@ public interface ModelService extends ModelObservable {
     AlreadyExistsException;
 
   void createTechnicalMetadata(String aipId, String representationId, String metadataType, String fileId,
+    ContentPayload payload, String createdBy, boolean notify) throws AuthorizationDeniedException,
+    RequestNotValidException, AlreadyExistsException, NotFoundException, GenericException;
+  
+  void updateTechnicalMetadata(String aipId, String representationId, String metadataType, String fileId,
     ContentPayload payload, String createdBy, boolean notify) throws AuthorizationDeniedException,
     RequestNotValidException, AlreadyExistsException, NotFoundException, GenericException;
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionalModelOperationRegistry.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/transaction/TransactionalModelOperationRegistry.java
@@ -33,6 +33,7 @@ import org.roda.core.data.v2.ip.Representation;
 import org.roda.core.data.v2.ip.TransferredResource;
 import org.roda.core.data.v2.ip.metadata.DescriptiveMetadata;
 import org.roda.core.data.v2.ip.metadata.PreservationMetadata;
+import org.roda.core.data.v2.ip.metadata.TechnicalMetadata;
 import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.Report;
 import org.roda.core.data.v2.log.LogEntry;
@@ -110,6 +111,21 @@ public class TransactionalModelOperationRegistry {
       operationLogs.add(registerOperation(DescriptiveMetadata.class,
         Arrays.asList(aipID, representationId, descriptiveMetadataId), operation));
     }
+    return operationLogs;
+  }
+
+  public List<TransactionalModelOperationLog> registerOperationForTechnicalMetadata(String aipID,
+    String representationId, List<String> fileDirectoryPath, String fileId, OperationType operation) {
+    List<TransactionalModelOperationLog> operationLogs = new ArrayList<>();
+    operationLogs.add(registerOperationForRelatedAIP(aipID, operation));
+    List<String> list = new ArrayList<>();
+    list.add(aipID);
+    list.addAll(fileDirectoryPath);
+    if (representationId != null) {
+      list.add(representationId);
+    }
+    list.add(fileId);
+    operationLogs.add(registerOperation(TechnicalMetadata.class, list, operation));
     return operationLogs;
   }
 
@@ -510,7 +526,6 @@ public class TransactionalModelOperationRegistry {
       throw new IllegalArgumentException(
         "[transactionId:" + transaction.getId() + "] Object class is not lockable: " + objectClass.getName());
     }
-
 
     Optional<LiteRODAObject> liteRODAObject = LiteRODAObjectFactory.get(objectClass, id);
     if (liteRODAObject.isPresent()) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
@@ -392,18 +392,18 @@ public class FilesService {
     NotFoundException, GenericException, TechnicalMetadataNotFoundException {
     ModelService model = requestContext.getModelService();
     Representation representation = model.retrieveRepresentation(file.getAipId(), file.getRepresentationId());
-    String techMDURN = URNUtils.createRodaTechnicalMetadataURN(file.getId(),
+    String techMDURN = URNUtils.createRodaTechnicalMetadataURN(IdUtils.createTechnicalMetadataFileId(file.getId(), file.getPath()),
       RODAInstanceUtils.getLocalInstanceIdentifier(), type.toLowerCase());
     Binary metadataBinary;
     if (versionID != null) {
       BinaryVersion binaryVersion = model.getBinaryVersion(representation, versionID,
         List.of(RodaConstants.STORAGE_DIRECTORY_METADATA, RodaConstants.STORAGE_DIRECTORY_TECHNICAL, type,
-          techMDURN + RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION));
+          techMDURN));
       metadataBinary = binaryVersion.getBinary();
     } else {
       metadataBinary = model.getBinary(representation, RodaConstants.STORAGE_DIRECTORY_METADATA,
         RodaConstants.STORAGE_DIRECTORY_TECHNICAL, type,
-        techMDURN + RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION);
+        techMDURN);
     }
     String filename = metadataBinary.getStoragePath().getName() + HTML_EXT;
     String htmlDescriptive = HTMLUtils.technicalMetadataToHtml(metadataBinary, type, versionID,
@@ -427,18 +427,18 @@ public class FilesService {
     StreamResponse ret;
     ModelService model = requestContext.getModelService();
     Representation representation = model.retrieveRepresentation(file.getAipId(), file.getRepresentationId());
-    String techMDURN = URNUtils.createRodaTechnicalMetadataURN(file.getId(),
+    String techMDURN = URNUtils.createRodaTechnicalMetadataURN(IdUtils.createTechnicalMetadataFileId(file.getId(), file.getPath()),
       RODAInstanceUtils.getLocalInstanceIdentifier(), type.toLowerCase());
     Binary metadataBinary;
     if (versionID != null) {
       BinaryVersion binaryVersion = model.getBinaryVersion(representation, versionID,
         List.of(RodaConstants.STORAGE_DIRECTORY_METADATA, RodaConstants.STORAGE_DIRECTORY_TECHNICAL, type,
-          techMDURN + RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION));
+          techMDURN));
       metadataBinary = binaryVersion.getBinary();
     } else {
       metadataBinary = model.getBinary(representation, RodaConstants.STORAGE_DIRECTORY_METADATA,
         RodaConstants.STORAGE_DIRECTORY_TECHNICAL, type,
-        techMDURN + RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION);
+        techMDURN);
     }
     stream = new BinaryConsumesOutputStream(metadataBinary, RodaConstants.MEDIA_TYPE_TEXT_XML);
 


### PR DESCRIPTION
- ensure technical metadata URNs include the correct file extension, createRodaTechnicalMetadataURN no longer returns only the prefix and - identifier, but also concatenates the constant REPRESENTATION_INFORMATION_FILE_EXTENSION
- prevent double-extension issues during Solr indexing by using the full URN in indexRepresentationTechnicalMetadata
- prevent directory files during Solr indexing
- extension is no longer manually appended to the URN when searching for the file in FilesService
- creation of retrieveTechnicalMetadataBinary and updateTechnicalMetadata for more complete technical metadata handling as well as operation register for Technical Metadata transactions
- creation of createTechnicalMetadataFileId so the URN reflects the full folder context
	- in order to fix collisions between same name files in different folders since it could overwrite each other's metadata or cause lookup failures
	- toSolrDocument uses the same method to generate the ID for indexing technical metadata, ensuring Solr documents are unique per file location