### PR TITLE
Skip Rollback on Validation Failure

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -1382,6 +1382,7 @@ public final class RodaConstants {
   public static final String PLUGIN_PARAMS_DONT_CHECK_RELATIVES = "parameter.dont_check_relatives";
   public static final String PLUGIN_PARAMS_REPRESENTATION_INFORMATION_FILTER = "parameter.representation_information_filter";
   public static final String PLUGIN_PARAMS_RODA_MEMBER_ACTIVATE = "parameter.activate";
+  public static final String PLUGIN_PARAM_SKIP_ROLLBACK_ON_VALIDATION_FAILURE = "parameter.skip_rollback_on_validation_failure";
 
   public static final String PLUGIN_PARAMS_VALIDATE_DESCRIPTIVE_METADATA = "parameter.validate_descriptive_metadata";
   public static final String PLUGIN_PARAMS_DESCRIPTIVE_METADATA_TYPE = "parameter.metadata_type";


### PR DESCRIPTION
- new RodaConstants.PLUGIN_PARAM_SKIP_ROLLBACK_ON_VALIDATION_FAILURE;
- transaction manager now checks for a plugin parameter that lists plugins for which transaction rollback should be skipped if they fail;
- when processing failed plugin reports, it only triggers a rollback if the failing plugin is not in the skip list; otherwise, the transaction continues;
- ensures that failures from plugins in the skip list do not cause the whole transaction to roll back.