### PR TITLE
Fix techMD ingest validation, repeated representation techMD types, and align UI technical metadata visibility

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -1366,6 +1366,7 @@ public final class RodaConstants {
   public static final String PLUGIN_PARAMS_AIP_ID = "parameter.aip_id";
   public static final String PLUGIN_PARAMS_ID = "parameter.id";
   public static final String PLUGIN_PARAMS_PERMISSIONS_JSON = "parameter.permissions_json";
+  public static final String PLUGIN_PARAMS_ENABLE_TECHMD_VALIDATION =  "parameter.enable_techmd_validation";
   public static final String PLUGIN_PARAMS_DETAILS = "parameter.details";
   public static final String PLUGIN_PARAMS_OUTCOME_TEXT = "parameter.outcome_text";
   public static final String PLUGIN_PARAMS_EVENT_DESCRIPTION = "parameter.event_description";

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/URNUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/URNUtils.java
@@ -160,6 +160,15 @@ public final class URNUtils {
     return fields[URN_INSTANCE_IDENTIFIER_POSITION];
   }
 
+  public static String extractFileIdFromTechnicalURN(String urnId) {
+    String s = urnId.trim();
+    if (s.endsWith(RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION)) {
+      s = s.substring(0, s.length() - RodaConstants.REPRESENTATION_INFORMATION_FILE_EXTENSION.length());
+    }
+
+    return s;
+  }
+
   public static boolean hasInstanceId(String id) {
     String[] fields = id.split(RodaConstants.URN_SEPARATOR);
     return !fields[URN_INSTANCE_IDENTIFIER_POSITION].equals(RodaConstants.PREMIS_METADATA_TYPE);

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/Representation.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/Representation.java
@@ -10,7 +10,9 @@ package org.roda.core.data.v2.ip;
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.v2.IsModelObject;
@@ -43,22 +45,22 @@ public class Representation implements IsModelObject, HasId, HasInstanceID {
   private String updatedBy = null;
 
   private List<DescriptiveMetadata> descriptiveMetadata = new ArrayList<>();
-  private List<TechnicalMetadata> technicalMetadata = new ArrayList<>();
+  private Set<TechnicalMetadata> technicalMetadata = new HashSet<>();
 
   public Representation() {
     super();
   }
 
   public Representation(String id, String aipId, boolean original, String type) {
-    this(id, aipId, original, type, null, new ArrayList<>(), new ArrayList<>(), false);
+    this(id, aipId, original, type, null, new ArrayList<>(), new HashSet<>(), false);
   }
 
   public Representation(String id, String aipId, boolean original, String type, Boolean hasShallowFiles) {
-    this(id, aipId, original, type, null, new ArrayList<>(), new ArrayList<>(), hasShallowFiles);
+    this(id, aipId, original, type, null, new ArrayList<>(), new HashSet<>(), hasShallowFiles);
   }
 
   public Representation(String id, String aipId, boolean original, String type, String instanceId,
-    List<DescriptiveMetadata> descriptiveMetadata, List<TechnicalMetadata> technicalMetadata, Boolean hasShallowFiles) {
+    List<DescriptiveMetadata> descriptiveMetadata, Set<TechnicalMetadata> technicalMetadata, Boolean hasShallowFiles) {
     super();
     this.id = id;
     this.aipId = aipId;
@@ -189,16 +191,16 @@ public class Representation implements IsModelObject, HasId, HasInstanceID {
     this.representationStates = states;
   }
 
-  public List<TechnicalMetadata> getTechnicalMetadata() {
+  public Set<TechnicalMetadata> getTechnicalMetadata() {
     return this.technicalMetadata;
   }
 
-  public void setTechnicalMetadata(List<TechnicalMetadata> technicalMetadata) {
+  public void setTechnicalMetadata(Set<TechnicalMetadata> technicalMetadata) {
     this.technicalMetadata = technicalMetadata;
   }
 
   public void addTechnicalMetadata(TechnicalMetadata technicalMetadata) {
-    this.technicalMetadata.add(technicalMetadata);
+      this.technicalMetadata.add(technicalMetadata);
   }
 
   @Override

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/TechnicalMetadata.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/ip/metadata/TechnicalMetadata.java
@@ -83,7 +83,7 @@ public class TechnicalMetadata implements IsModelObject {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || getClass() != o.getClass())
+    if (!(o instanceof TechnicalMetadata))
       return false;
     TechnicalMetadata that = (TechnicalMetadata) o;
     return Objects.equals(id, that.id) && Objects.equals(aipId, that.aipId)

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultModelService.java
@@ -1814,10 +1814,10 @@ public class DefaultModelService implements ModelService {
     StoragePath binaryPath = ModelUtils.getTechnicalMetadataStoragePath(aipId, representationId,
       Collections.singletonList(metadataType), urn);
     storage.updateBinaryContent(binaryPath, payload, false, false, true, null);
-    // update technicalmetadata logic
+    // update technical metadata logic
     if (aipId != null) {
       AIP aip = ResourceParseUtils.getAIPMetadata(getStorage(), aipId);
-      List<TechnicalMetadata> techMetadataList = getTechnicalMetadata(aip, representationId);
+      Set<TechnicalMetadata> techMetadataList = getTechnicalMetadata(aip, representationId);
       techMetadataList.removeIf(tm -> tm.getId().equals(metadataType));
       addTechnicalMetadataToAIPMetadata(aip, representationId, metadataType, createdBy, notify);
     }
@@ -1836,9 +1836,9 @@ public class DefaultModelService implements ModelService {
     }
   }
 
-  private List<TechnicalMetadata> getTechnicalMetadata(AIP aip, String representationId) {
+  private Set<TechnicalMetadata> getTechnicalMetadata(AIP aip, String representationId) {
     if (representationId == null) {
-      return new ArrayList<>();
+      return new HashSet<>();
     }
     Optional<Representation> oRep = aip.getRepresentations().stream()
       .filter(rep -> rep.getId().equals(representationId)).findFirst();
@@ -1846,7 +1846,7 @@ public class DefaultModelService implements ModelService {
       return oRep.get().getTechnicalMetadata();
     }
 
-    return new ArrayList<>();
+    return new HashSet<>();
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/ModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/ModelService.java
@@ -389,7 +389,7 @@ public interface ModelService extends ModelObservable {
     ContentPayload payload, String createdBy, boolean notify) throws AuthorizationDeniedException,
     RequestNotValidException, AlreadyExistsException, NotFoundException, GenericException;
 
-  public PreservationMetadata createPreservationMetadata(PreservationMetadataType type, String aipId,
+  PreservationMetadata createPreservationMetadata(PreservationMetadataType type, String aipId,
     List<String> fileDirectoryPath, String fileId, ContentPayload payload, String username, boolean notify)
     throws GenericException, NotFoundException, RequestNotValidException, AuthorizationDeniedException,
     AlreadyExistsException;

--- a/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIP2ToAIPPlugin.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/plugins/base/ingest/EARKSIP2ToAIPPlugin.java
@@ -49,7 +49,6 @@ import org.roda.core.plugins.Plugin;
 import org.roda.core.plugins.PluginException;
 import org.roda.core.plugins.PluginHelper;
 import org.roda.core.plugins.RODAObjectProcessingLogic;
-import org.roda.core.plugins.orchestrate.JobsHelper;
 import org.roda.core.storage.fs.FSUtils;
 import org.roda_project.commons_ip.model.ParseException;
 import org.roda_project.commons_ip.utils.IPEnums;
@@ -65,6 +64,7 @@ public class EARKSIP2ToAIPPlugin extends SIPToAIPPlugin {
 
   private Optional<String> computedSearchScope;
   private boolean forceSearchScope;
+  private boolean enableTechMDValidation = true;
   private Path jobWorkingDirectory;
 
   @Override
@@ -98,6 +98,11 @@ public class EARKSIP2ToAIPPlugin extends SIPToAIPPlugin {
 
     if (getParameterValues().containsKey(RodaConstants.PLUGIN_PARAMS_CREATE_SUBMISSION)) {
       createSubmission = Boolean.parseBoolean(getParameterValues().get(RodaConstants.PLUGIN_PARAMS_CREATE_SUBMISSION));
+    }
+
+    if (getParameterValues().containsKey(RodaConstants.PLUGIN_PARAMS_ENABLE_TECHMD_VALIDATION)) {
+      enableTechMDValidation = Boolean
+        .parseBoolean(getParameterValues().get(RodaConstants.PLUGIN_PARAMS_ENABLE_TECHMD_VALIDATION));
     }
   }
 
@@ -197,8 +202,8 @@ public class EARKSIP2ToAIPPlugin extends SIPToAIPPlugin {
     throws NotFoundException, GenericException, RequestNotValidException, AuthorizationDeniedException,
     AlreadyExistsException, ValidationException, LockingException {
     String jobUsername = PluginHelper.getJobUsername(this, index);
-    return EARKSIP2ToAIPPluginUtils.earkSIPToAIP(sip, jobUsername, model, sip.getIds(), reportItem.getJobId(),
-      computedParentId, ingestSIPUUID, this);
+    return EARKSIP2ToAIPPluginUtils.earkSIPToAIP(sip, jobUsername, model, enableTechMDValidation, sip.getIds(),
+      reportItem.getJobId(), computedParentId, ingestSIPUUID, this);
   }
 
   private AIP processUpdateSIP(IndexService index, ModelService model, SIP sip, Optional<String> searchScope,
@@ -243,8 +248,8 @@ public class EARKSIP2ToAIPPlugin extends SIPToAIPPlugin {
     String jobId = PluginHelper.getJobId(this);
 
     // Update the AIP
-    return EARKSIP2ToAIPPluginUtils.earkSIPToAIPUpdate(sip, indexedAIP, model, jobUsername, searchScope, jobId, null,
-      this);
+    return EARKSIP2ToAIPPluginUtils.earkSIPToAIPUpdate(sip, indexedAIP, model, enableTechMDValidation, jobUsername,
+      searchScope, jobId, null, this);
   }
 
   @Override

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/FilesService.java
@@ -375,15 +375,21 @@ public class FilesService {
     Locale locale = ServerTools.parseLocale(localeString);
     Messages messages = RodaCoreFactory.getI18NMessages(locale);
 
+    List<String> techMdTypes = file.getTechnicalMetadataIds();
+    if (techMdTypes == null || techMdTypes.isEmpty()) {
+      return new TechnicalMetadataInfos();
+    }
+
     Representation representation = model.retrieveRepresentation(file.getAipId(), file.getRepresentationId());
 
     for (TechnicalMetadata technicalMetadata : representation.getTechnicalMetadata()) {
       String type = technicalMetadata.getType();
-      String label = messages.getTranslation(
-        RodaConstants.I18N_UI_BROWSE_METADATA_TECHNICAL_TYPE_PREFIX + type.toLowerCase(), technicalMetadata.getId());
-      technicalMetadataInfos.addObject(new TechnicalMetadataInfo(type, label));
+      if (techMdTypes.contains(type.toLowerCase())) {
+        String label = messages.getTranslation(
+          RodaConstants.I18N_UI_BROWSE_METADATA_TECHNICAL_TYPE_PREFIX + type.toLowerCase(), technicalMetadata.getId());
+        technicalMetadataInfos.addObject(new TechnicalMetadataInfo(type, label));
+      }
     }
-
     return technicalMetadataInfos;
   }
 


### PR DESCRIPTION
### Ingestion

**EARKSIP2ToAIPPlugin**

- added a new `PLUGIN_PARAMS_ENABLE_TECHMD_VALIDATION` parameter to enable technical metadata (techMD) validation, enabled by default
- propagated the validation parameter to both `earkSIPToAIP` and `earkSIPToAIPUpdate`

**EARKSIP2ToAIPPluginUtils**

- following per-file validation, each techMD filename is validated against the representation’s data files (must match an existing file)
- created `URNUtils.extractFileIdFromTechnicalURN` helper to normalize the correct `fileId` from the techMD filename before validation and creation
- for valid techMD in `processTechnicalMetadata`, the ingest calls `model.createTechnicalMetadata `using the `fileId` that matches the representation file, so the technical metadata URN remains file-scoped
- when validation is disabled, techMD is created using the filename as received in the SIP

----
### Model

**TechnicalMetadata**

- adjusted `.equals` type check to be instanceof based

**Representation**

- changed the technicalMetadata collection from `List` to `Set` to prevent the same technical metadata type from being added multiple times to the same representation

**DefaultModelService**

- maintains existing storage semantics in `model.createTechnicalMetadata`
- updated internal flow to align with the Set change in `model.getTechnicalMetadata` and `model.updateTechnicalMetadata`

----
### Index

**SolrUtils.indexRepresentationTechnicalMetadata**

- fixed `indexedRepresentationTechnicalMetadata` to only add a techMD type into `FILE_TECHNICAL_METADATA_ID` if the corresponding technical metadata binary actually exists in storage

----
### Services / UI API Behaviour

**FilesService**

- `retrieveFileTechnicalMetadataInfos` now filters representation-level techMD types by the file’s indexed list, returning only the types that are actually present for that file
- aligns UI behaviour: the Technical metadata tab is only available when the current file has `technicalMetadataId `populated