### PR TITLE
Fix newType parameter in RepresentationPanel

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/PluginParameterPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/ingest/process/PluginParameterPanel.java
@@ -246,12 +246,10 @@ public class PluginParameterPanel extends Composite {
             selectBox.addItem(option);
           }
 
-          if (options.isControlledVocabulary()) {
-            selectBox.addItem(messages.entityTypeAddNew(), ADD_TYPE);
-          }
+          selectBox.addItem(messages.entityTypeAddNew(), ADD_TYPE);
           selectBox.setSelectedIndex(0);
           value = selectBox.getSelectedValue();
-          representationParameter.setValue(selectBox.getSelectedValue());
+          representationParameter.setValue(value);
         }
       });
 


### PR DESCRIPTION
- Makes sure that 'Add new' representation type option is always exposed in the UI
- Removed implicit dependency on `controlledVocabulary`