### PR TITLE
Mask expirationDate_dt field in html

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/crosswalks/dissemination/html/key-value.xslt
+++ b/roda-ui/roda-wui/src/main/resources/config/crosswalks/dissemination/html/key-value.xslt
@@ -3,6 +3,7 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 	<xsl:output method="xml" indent="yes" encoding="UTF-8"
 		omit-xml-declaration="yes" />
+	<xsl:param name="i18n.expirationDate_dt" />
 
 	<xsl:template match="/">
 		<div class="descriptiveMetadata">
@@ -13,7 +14,14 @@
 		<xsl:if test="normalize-space(text())!=''">
 			<div class="field">
 				<div class="label">
-					<xsl:value-of select="@name" />
+					<xsl:choose>
+						<xsl:when test="@name='expirationDate_dt' and string($i18n.expirationDate_dt)!=''">
+							<xsl:value-of select="$i18n.expirationDate_dt"/>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:value-of select="@name"/>
+						</xsl:otherwise>
+					</xsl:choose>
 				</div>
 				<div class="value">
 					<xsl:value-of select="text()" />

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages.properties
@@ -569,6 +569,8 @@ crosswalks.dissemination.html.event.detail: Detail
 crosswalks.dissemination.html.event.outcomeDetailNote: Note
 crosswalks.dissemination.html.event.outcomeDetailExtension: Extension
 
+crosswalks.dissemination.html.key-value.expirationDate_dt=Expiration date
+
 ##########################################
 # Representation information families
 ##########################################

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages_pt_PT.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/ServerMessages_pt_PT.properties
@@ -563,6 +563,8 @@ crosswalks.dissemination.html.event.detail: Detalhe
 crosswalks.dissemination.html.event.outcomeDetailNote: Nota
 crosswalks.dissemination.html.event.outcomeDetailExtension: Extensão
 
+crosswalks.dissemination.html.key-value.expirationDate_dt=Data de expiração
+
 ##########################################
 # Representation information families
 ##########################################


### PR DESCRIPTION
- masked the label of the expirationDate_dt field in the HTML of the metadata key‑value using i18n
- translation crosswalks.dissemination.html.key-value.expirationDate_dt for PT
- maintained fallback for other fields with the original @name in key-value.xslt