### PR TITLE
Exclude Xalan from GWT Dev Dependencies

### DIFF
--- a/roda-ui/roda-wui/pom.xml
+++ b/roda-ui/roda-wui/pom.xml
@@ -371,6 +371,14 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>apache-jsp</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>xalan</groupId>
+                    <artifactId>xalan</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xalan</groupId>
+                    <artifactId>serializer</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- /gwt -->


### PR DESCRIPTION
- excludes xalan dependency from the GWT dev toolchain to avoid conflicts with the jdk xml transformer