### PR TITLE
Fix condition in retrieveJobAttachments

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/JobService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/JobService.java
@@ -246,7 +246,7 @@ public class JobService {
   public StreamResponse retrieveJobAttachment(String jobId, String attachmentId) throws NotFoundException, GenericException {
     Path filePath = RodaCoreFactory.getJobAttachmentsDirectoryPath().resolve(jobId).resolve(attachmentId);
 
-    if (!RodaCoreFactory.getJobAttachmentsDirectoryPath().startsWith(filePath)) {
+    if (!filePath.startsWith(RodaCoreFactory.getJobAttachmentsDirectoryPath())) {
       throw new GenericException("Attempt to retrieve files outside the permitted scope");
     }
 


### PR DESCRIPTION
- path-scope validation bug in `retrieveJobAttachment`
- startsWith check was reversed and now correctly validates that the resolved attachment path starts with the attachments base directory