### PR TITLE
Transactional importObject method

### DIFF
--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/DeleteAIPPermissionTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/storage/DeleteAIPPermissionTest.java
@@ -65,8 +65,8 @@ public class DeleteAIPPermissionTest {
   private static LdapUtilityTestHelper ldapUtilityTestHelper;
 
   @BeforeMethod
-  public static void setUp() throws Exception {
-    basePath = TestsHelper.createBaseTempDir(FileStorageServiceTest.class, true);
+  public void setUp() throws Exception {
+    basePath = TestsHelper.createBaseTempDir(this.getClass(), true);
     ldapUtilityTestHelper = new LdapUtilityTestHelper();
 
     RodaCoreFactory.instantiateTest(true, true, true, true, true, false, false, ldapUtilityTestHelper.getLdapUtility());

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/ModelObserver.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/ModelObserver.java
@@ -10,6 +10,7 @@ package org.roda.core.model;
 import java.util.List;
 
 import org.roda.core.data.exceptions.ReturnWithExceptions;
+import org.roda.core.data.v2.LiteRODAObject;
 import org.roda.core.data.v2.disposal.confirmation.DisposalConfirmation;
 import org.roda.core.data.v2.ip.AIP;
 import org.roda.core.data.v2.ip.DIP;
@@ -151,4 +152,10 @@ public interface ModelObserver {
     DisposalConfirmation confirmation);
 
   public ReturnWithExceptions<Void, ModelObserver> disposalConfirmationDeleted(String confirmationId, boolean commit);
+
+  public ReturnWithExceptions<Void, ModelObserver> liteRODAObjectCreated(LiteRODAObject liteRODAObject);
+
+  public ReturnWithExceptions<Void, ModelObserver> liteRODAObjectUpdated(LiteRODAObject liteRODAObject);
+
+  public ReturnWithExceptions<Void, ModelObserver> liteRODAObjectDeleted(LiteRODAObject liteRODAObject);
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/ModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/ModelService.java
@@ -973,7 +973,8 @@ public interface ModelService extends ModelObservable {
 
   void exportAll(StorageService toStorage);
 
-  void importObject(IsRODAObject object, StorageService fromStorage);
+  void importObject(ModelService fromModel, LiteRODAObject object, boolean replaceExisting) throws RequestNotValidException,
+    GenericException, NotFoundException, AuthorizationDeniedException, AlreadyExistsException;
 
   void exportObject(IsRODAObject object, StorageService toStorage, String... toPathPartials)
     throws RequestNotValidException, AuthorizationDeniedException, AlreadyExistsException, NotFoundException,

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/StorageService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/StorageService.java
@@ -18,6 +18,7 @@ import org.roda.core.data.exceptions.AuthorizationDeniedException;
 import org.roda.core.data.exceptions.GenericException;
 import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.exceptions.RequestNotValidException;
+import org.roda.core.data.v2.LiteRODAObject;
 import org.roda.core.data.v2.ip.StoragePath;
 
 /**
@@ -354,6 +355,12 @@ public interface StorageService {
   @Deprecated
   void copy(StorageService fromService, StoragePath fromStoragePath, Path toPath, String resource,
     boolean replaceExisting) throws AlreadyExistsException, GenericException, AuthorizationDeniedException;
+
+
+  default void importObject(StorageService fromService, LiteRODAObject object, StoragePath toStoragePath, boolean replaceExisting)
+          throws AlreadyExistsException, GenericException, AuthorizationDeniedException, NotFoundException, RequestNotValidException {
+    throw new UnsupportedOperationException("Not supported yet.");
+  };
 
   /**
    * Move resources from another (or the same) storage service.

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/StorageServiceWrapper.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/StorageServiceWrapper.java
@@ -20,6 +20,7 @@ import org.roda.core.data.exceptions.AuthorizationDeniedException;
 import org.roda.core.data.exceptions.GenericException;
 import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.exceptions.RequestNotValidException;
+import org.roda.core.data.v2.LiteRODAObject;
 import org.roda.core.data.v2.ip.StoragePath;
 
 public class StorageServiceWrapper implements StorageService {
@@ -183,6 +184,14 @@ public class StorageServiceWrapper implements StorageService {
     boolean replaceExisting) throws AlreadyExistsException, GenericException, AuthorizationDeniedException {
     RodaCoreFactory.checkIfWriteIsAllowedAndIfFalseThrowException(nodeType);
     storageService.copy(fromService, fromStoragePath, toPath, resource, replaceExisting);
+  }
+
+  @Override
+  public void importObject(StorageService fromService, LiteRODAObject object, StoragePath toStoragePath,
+    boolean replaceExisting) throws AlreadyExistsException, GenericException, AuthorizationDeniedException,
+    NotFoundException, RequestNotValidException {
+    RodaCoreFactory.checkIfWriteIsAllowedAndIfFalseThrowException(nodeType);
+    storageService.importObject(fromService, object, toStoragePath, replaceExisting);
   }
 
   @Override

--- a/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FileStorageService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/storage/fs/FileStorageService.java
@@ -34,6 +34,7 @@ import org.roda.core.data.exceptions.GenericException;
 import org.roda.core.data.exceptions.NotFoundException;
 import org.roda.core.data.exceptions.RequestNotValidException;
 import org.roda.core.data.utils.JsonUtils;
+import org.roda.core.data.v2.LiteRODAObject;
 import org.roda.core.data.v2.ip.ShallowFile;
 import org.roda.core.data.v2.ip.ShallowFiles;
 import org.roda.core.data.v2.ip.StoragePath;
@@ -577,6 +578,26 @@ public class FileStorageService implements StorageService {
     if (FSUtils.exists(sourcePath)) {
       FSUtils.copy(sourcePath, toPath, replaceExisting);
     }
+  }
+
+  @Override
+  public void importObject(StorageService fromService, LiteRODAObject object, StoragePath toStoragePath,
+    boolean replaceExisting) throws AlreadyExistsException, GenericException, NotFoundException,
+    AuthorizationDeniedException, RequestNotValidException {
+    StoragePath fromPath = ModelUtils.getStoragePath(object);
+    if (!fromService.exists(fromPath)) {
+      throw new NotFoundException("Source Path does not exist: " + fromPath);
+    }
+
+    if (exists(toStoragePath)) {
+      if(replaceExisting) {
+        // workaround
+        deleteResource(toStoragePath);
+      } else {
+        throw new AlreadyExistsException("Destination already exists: " + toStoragePath);
+      }
+    }
+    copy(fromService, fromPath, toStoragePath);
   }
 
   @Override


### PR DESCRIPTION
- `importObject` was added as a default method, its signature evolved to accept `fromModel,` `LiteRODAObject` and `replaceExisting`, avoiding breaking existent storage implementations;
- transactional model flow supports `replaceExisting` to distinguish create vs update intent, keeping proper failure tracking;
- aligned notification to support `LiteRODAObject` create/update/delete  callbacks for index synchronization after import;