### PR TITLE
Aflores dev fix transfer update role

### DIFF
--- a/roda-core/roda-core/src/main/resources/config/roda-roles.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-roles.properties
@@ -76,7 +76,7 @@ core.roles.org.roda.wui.api.v2.controller.TransferredResourceController.download
 core.roles.org.roda.wui.api.v2.controller.TransferredResourceController.getSelectedTransferredResources = transfer.read
 core.roles.org.roda.wui.api.v2.controller.TransferredResourceController.createTransferredResource = transfer.create
 core.roles.org.roda.wui.api.v2.controller.TransferredResourceController.reindexResources = transfer.create
-core.roles.org.roda.wui.api.v2.controller.TransferredResourceController.renameTransferredResource = transfer.create
+core.roles.org.roda.wui.api.v2.controller.TransferredResourceController.renameTransferredResource = transfer.update
 core.roles.org.roda.wui.api.v2.controller.TransferredResourceController.refreshTransferResource = transfer.read
 core.roles.org.roda.wui.api.v2.controller.TransferredResourceController.moveTransferredResources = transfer.create
 


### PR DESCRIPTION
Changes `renameTransferredResource` role to use the `transfer.update` permission. This permission was unused and therefore never initialized in the LDAP role repository, which caused issues when assigning it to users.