### PR TITLE
Add script to configure Maven settings from environment variables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,15 @@ roda/
 4. **GitHub account with PAT** — required for GitHub Packages dependency resolution
 
 **Configure Maven for GitHub Packages** (`~/.m2/settings.xml`):
+
+The easiest way is to set the environment variables and run the provided script:
+```bash
+export GITHUB_MAVEN_USER=YOUR_GITHUB_USERNAME
+export GITHUB_MAVEN_PASSWORD=YOUR_GITHUB_PAT
+./scripts/setup_maven_settings.sh
+```
+
+Alternatively, create `~/.m2/settings.xml` manually:
 ```xml
 <settings>
   <servers>

--- a/scripts/setup_maven_settings.sh
+++ b/scripts/setup_maven_settings.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Creates ~/.m2/settings.xml using GITHUB_MAVEN_USER and GITHUB_MAVEN_PASSWORD
+# environment variables for GitHub Packages authentication.
+
+set -e
+
+if [ -z "$GITHUB_MAVEN_USER" ] || [ -z "$GITHUB_MAVEN_PASSWORD" ]; then
+  echo "Error: GITHUB_MAVEN_USER and GITHUB_MAVEN_PASSWORD must be set." >&2
+  exit 1
+fi
+
+mkdir -p "$HOME/.m2"
+
+cat > "$HOME/.m2/settings.xml" << EOF
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>${GITHUB_MAVEN_USER}</username>
+      <password>${GITHUB_MAVEN_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>
+EOF
+
+echo "Maven settings.xml written to $HOME/.m2/settings.xml"


### PR DESCRIPTION
## Summary

- Adds `scripts/setup_maven_settings.sh` to generate `~/.m2/settings.xml` from `GITHUB_MAVEN_USER` and `GITHUB_MAVEN_PASSWORD` environment variables
- Script must be run before any Maven build that requires GitHub Packages authentication

## Usage

```bash
export GITHUB_MAVEN_USER=your_username
export GITHUB_MAVEN_PASSWORD=your_pat
./scripts/setup_maven_settings.sh
```

https://claude.ai/code/session_01C16yKTzMvrJbwSNTVAWLRK