### PR TITLE
New layout UI for Audit log detailed page

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseLogEntryTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseLogEntryTabs.java
@@ -1,0 +1,21 @@
+package org.roda.wui.client.browse.tabs;
+
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
+import com.google.gwt.user.client.ui.Widget;
+import org.roda.core.data.v2.log.LogEntry;
+
+/**
+ *
+ * @author Eduardo Teixeira <eteixeira@keep.pt>
+ */
+public class BrowseLogEntryTabs extends Tabs {
+  public void init(LogEntry logEntry) {
+    // Details
+    createAndAddTab(SafeHtmlUtils.fromSafeConstant(messages.detailsTab()), new TabContentBuilder() {
+      @Override
+      public Widget buildTabWidget() {
+        return new DetailsTab(logEntry);
+      }
+    });
+  }
+}

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/DetailsTab.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/DetailsTab.java
@@ -11,8 +11,10 @@ import java.util.List;
 
 import org.roda.core.data.v2.ip.IndexedFile;
 import org.roda.core.data.v2.ip.TransferredResource;
+import org.roda.core.data.v2.log.LogEntry;
 import org.roda.wui.client.common.model.BrowseAIPResponse;
 import org.roda.wui.client.common.model.BrowseRepresentationResponse;
+import org.roda.wui.client.management.DetailsPanelLogEntry;
 import org.roda.wui.client.ingest.transfer.DetailsPanelTransferredResource;
 import org.roda.wui.client.planning.DetailsPanelAIP;
 import org.roda.wui.client.planning.DetailsPanelFile;
@@ -62,6 +64,12 @@ public class DetailsTab extends Composite {
     initWidget(uiBinder.createAndBindUi(this));
 
     DetailsPanelTransferredResource detailsPanel = new DetailsPanelTransferredResource(resource);
+    content.add(detailsPanel);
+  }
+
+  public DetailsTab(LogEntry logEntry) {
+    initWidget(uiBinder.createAndBindUi(this));
+    DetailsPanelLogEntry detailsPanel = new DetailsPanelLogEntry(logEntry);
     content.add(detailsPanel);
   }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/BreadcrumbUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/BreadcrumbUtils.java
@@ -19,7 +19,10 @@ import org.roda.core.data.v2.ip.IndexedDIP;
 import org.roda.core.data.v2.ip.IndexedFile;
 import org.roda.core.data.v2.ip.IndexedRepresentation;
 import org.roda.core.data.v2.ip.TransferredResource;
+import org.roda.core.data.v2.log.LogEntry;
 import org.roda.wui.client.browse.BrowseTop;
+import org.roda.wui.client.management.ShowLogEntry;
+import org.roda.wui.client.management.UserLog;
 import org.roda.wui.client.browse.PreservationEvents;
 import org.roda.wui.client.disposal.DisposalDestroyedRecords;
 import org.roda.wui.client.ingest.appraisal.IngestAppraisal;
@@ -27,6 +30,7 @@ import org.roda.wui.client.ingest.transfer.IngestTransfer;
 import org.roda.wui.common.client.tools.DescriptionLevelUtils;
 import org.roda.wui.common.client.tools.HistoryUtils;
 import org.roda.wui.common.client.tools.ListUtils;
+import org.roda.wui.common.client.tools.StringUtils;
 import org.roda.wui.common.client.widgets.Toast;
 
 import com.google.gwt.core.client.GWT;
@@ -347,6 +351,21 @@ public class BreadcrumbUtils {
       path.add(r.getUUID());
       SafeHtml breadcrumbLabel = SafeHtmlUtils.fromString(r.getName());
       ret.add(new BreadcrumbItem(breadcrumbLabel, r.getName(), path));
+    }
+
+    return ret;
+  }
+
+  public static List<BreadcrumbItem> getLogEntryBreadcrumbs(LogEntry logEntry) {
+    List<BreadcrumbItem> ret = new ArrayList<>();
+    ret.add(new BreadcrumbItem(SafeHtmlUtils.fromSafeConstant(messages.activityLogTitle()),
+            messages.activityLogTitle(), UserLog.RESOLVER.getHistoryPath()));
+
+    if (logEntry != null) {
+      List<String> path = new ArrayList<>(ShowLogEntry.RESOLVER.getHistoryPath());
+      path.add(logEntry.getUUID());
+      String label = StringUtils.isNotBlank(logEntry.getId()) ? logEntry.getId() : logEntry.getUUID();
+      ret.add(new BreadcrumbItem(SafeHtmlUtils.fromString(label), label, path));
     }
 
     return ret;

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/DetailsPanelLogEntry.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/DetailsPanelLogEntry.java
@@ -1,0 +1,94 @@
+package org.roda.wui.client.management;
+
+import org.roda.core.data.v2.log.LogEntry;
+import org.roda.wui.client.common.utils.HtmlSnippetUtils;
+import org.roda.wui.common.client.tools.Humanize;
+import org.roda.wui.common.client.tools.StringUtils;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.InlineHTML;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+
+import config.i18n.client.ClientMessages;
+
+/**
+ *
+ * @author Eduardo Teixeira <eteixeira@keep.pt>
+ */
+public class DetailsPanelLogEntry extends Composite {
+  private static final ClientMessages messages = GWT.create(ClientMessages.class);
+  private static final MyUiBinder uiBinder = GWT.create(MyUiBinder.class);
+
+  @UiField
+  FlowPanel details;
+
+  public DetailsPanelLogEntry(LogEntry logEntry) {
+    initWidget(uiBinder.createAndBindUi(this));
+    init(logEntry);
+  }
+
+  private void init(LogEntry logEntry) {
+    addIfNotBlank(messages.logEntryIdentifier(), logEntry.getId());
+    addIfNotBlank(messages.logEntryReason(),
+      logEntry.getAuditLogRequestHeaders() != null ? logEntry.getAuditLogRequestHeaders().getReason() : null);
+    addIfNotBlank(messages.logEntryInstanceId(), logEntry.getInstanceId());
+    addIfNotBlank(messages.logEntryComponent(), logEntry.getActionComponent());
+    addIfNotBlank(messages.logEntryMethod(), logEntry.getActionMethod());
+    addIfNotBlank(messages.logEntryAddress(), logEntry.getAddress());
+
+    if (logEntry.getDatetime() != null) {
+      details.add(buildField(messages.logEntryDatetime(),
+        new InlineHTML(SafeHtmlUtils.htmlEscape(Humanize.formatDateTime(logEntry.getDatetime())))));
+    }
+
+    details.add(buildField(messages.logEntryDuration(),
+      new InlineHTML(SafeHtmlUtils.htmlEscape(Humanize.durationMillisToShortDHMS(logEntry.getDuration())))));
+
+    addIfNotBlank(messages.logEntryRelatedObject(), logEntry.getRelatedObjectID());
+    addIfNotBlank(messages.logEntryUsername(), logEntry.getUsername());
+
+    if (logEntry.getParameters() != null && !logEntry.getParameters().isEmpty()) {
+      String paramsInline = logEntry.getParameters().stream().map(p -> messages.logParameter(p.getName(), p.getValue()))
+        .collect(java.util.stream.Collectors.joining(" | "));
+      details.add(buildField(messages.logEntryParameters(), new InlineHTML(SafeHtmlUtils.htmlEscape(paramsInline))));
+    }
+
+    if (logEntry.getState() != null) {
+      details.add(buildField(messages.logEntryState(),
+        new InlineHTML(HtmlSnippetUtils.getLogEntryStateHtml(logEntry.getState()))));
+    }
+  }
+
+  private void addIfNotBlank(String label, String value) {
+    if (StringUtils.isNotBlank(value)) {
+      details.add(buildField(label, new InlineHTML(SafeHtmlUtils.htmlEscape(value))));
+    }
+  }
+
+  private FlowPanel buildField(String labelText, InlineHTML html) {
+    FlowPanel field = new FlowPanel();
+    field.setStyleName("field");
+
+    Label label = new Label(labelText);
+    label.setStyleName("label");
+
+    FlowPanel value = new FlowPanel();
+    value.setStyleName("value");
+    value.add(html);
+
+    field.add(label);
+    field.add(value);
+    return field;
+  }
+
+  interface MyUiBinder extends UiBinder<Widget, DetailsPanelLogEntry> {
+    Widget createAndBindUi(DetailsPanelLogEntry detailsPanelLogEntry);
+  }
+
+}

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/DetailsPanelLogEntry.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/DetailsPanelLogEntry.ui.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:g="urn:import:com.google.gwt.user.client.ui"
+>
+
+    <ui:with field='messages' type='config.i18n.client.ClientMessages'/>
+
+    <g:FlowPanel addStyleNames="descriptiveMetadataHTML">
+        <g:FlowPanel ui:field="details" addStyleNames="descriptiveMetadata"/>
+
+    </g:FlowPanel>
+</ui:UiBinder>

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowLogEntry.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowLogEntry.java
@@ -12,35 +12,35 @@ package org.roda.wui.client.management;
 
 import java.util.List;
 
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.SimplePanel;
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.v2.index.filter.Filter;
 import org.roda.core.data.v2.index.filter.SimpleFilterParameter;
 import org.roda.core.data.v2.log.LogEntry;
-import org.roda.core.data.v2.log.LogEntryParameter;
+import org.roda.wui.client.browse.tabs.BrowseLogEntryTabs;
+import org.roda.wui.client.common.ActionsToolbar;
+import org.roda.wui.client.common.NavigationToolbar;
+import org.roda.wui.client.common.TitlePanel;
 import org.roda.wui.client.common.UserLogin;
 import org.roda.wui.client.common.lists.InternalLogEntryList;
 import org.roda.wui.client.common.lists.utils.AsyncTableCellOptions;
 import org.roda.wui.client.common.lists.utils.ListBuilder;
 import org.roda.wui.client.common.search.SearchWrapper;
-import org.roda.wui.client.common.utils.HtmlSnippetUtils;
+import org.roda.wui.client.main.BreadcrumbUtils;
 import org.roda.wui.client.services.Services;
 import org.roda.wui.common.client.HistoryResolver;
 import org.roda.wui.common.client.tools.HistoryUtils;
-import org.roda.wui.common.client.tools.Humanize;
 import org.roda.wui.common.client.tools.ListUtils;
 import org.roda.wui.common.client.tools.StringUtils;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.i18n.client.LocaleInfo;
-import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HTML;
-import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.SimplePanel;
+import com.google.gwt.user.client.ui.FocusPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
@@ -95,121 +95,33 @@ public class ShowLogEntry extends Composite {
   private static final ClientMessages messages = GWT.create(ClientMessages.class);
 
   @UiField
-  Label logIdLabel;
+  FocusPanel keyboardFocus;
   @UiField
-  Label logIdValue;
+  NavigationToolbar<LogEntry> navigationToolbar;
   @UiField
-  Label logReasonLabel;
+  ActionsToolbar actionsToolbar;
   @UiField
-  Label logReasonValue;
+  TitlePanel title;
   @UiField
-  Label logComponentLabel;
-  @UiField
-  Label logComponentValue;
-  @UiField
-  Label logMethodLabel;
-  @UiField
-  Label logMethodValue;
-  @UiField
-  Label logAddressLabel;
-  @UiField
-  Label logAddressValue;
-  @UiField
-  Label logDatetimeLabel;
-  @UiField
-  Label logDatetimeValue;
-  @UiField
-  Label logDurationValue;
-  @UiField
-  Label logRelatedObjectLabel;
-  @UiField
-  Label logRelatedObjectValue;
-  @UiField
-  Label logUsernameLabel;
-  @UiField
-  Label logUsernameValue;
-  @UiField
-  Label logParametersLabel;
-  @UiField
-  FlowPanel logParametersValue;
-  @UiField
-  Label logStateLabel;
-  @UiField
-  HTML logStateValue;
-  @UiField
-  Label logInstanceIdLabel;
-  @UiField
-  Label logInstanceIdValue;
+  BrowseLogEntryTabs browseTab;
   @UiField
   SimplePanel expandedAuditLogs;
   @UiField
   SimplePanel expandedAuditLogsList;
-
   /**
    * Create a new panel to view a log entry
    *
    */
   public ShowLogEntry(LogEntry logEntry) {
     initWidget(uiBinder.createAndBindUi(this));
+    navigationToolbar.withoutButtons().build();
+    navigationToolbar.updateBreadcrumbPath(BreadcrumbUtils.getLogEntryBreadcrumbs(logEntry));
 
-    logIdValue.setText(logEntry.getId());
-    logIdLabel.setVisible(StringUtils.isNotBlank(logEntry.getId()));
-    logIdValue.setVisible(StringUtils.isNotBlank(logEntry.getId()));
-
-    logReasonValue.setText(logEntry.getAuditLogRequestHeaders().getReason());
-    logReasonLabel.setVisible(StringUtils.isNotBlank(logEntry.getAuditLogRequestHeaders().getReason()));
-    logReasonValue.setVisible(StringUtils.isNotBlank(logEntry.getAuditLogRequestHeaders().getReason()));
-
-    logInstanceIdValue.setText(logEntry.getInstanceId());
-    logInstanceIdLabel.setVisible(StringUtils.isNotBlank(logEntry.getInstanceId()));
-    logInstanceIdValue.setVisible(StringUtils.isNotBlank(logEntry.getInstanceId()));
-
-    logComponentValue.setText(logEntry.getActionComponent());
-    logComponentLabel.setVisible(StringUtils.isNotBlank(logEntry.getActionComponent()));
-    logComponentValue.setVisible(StringUtils.isNotBlank(logEntry.getActionComponent()));
-
-    logMethodValue.setText(logEntry.getActionMethod());
-    logMethodLabel.setVisible(StringUtils.isNotBlank(logEntry.getActionMethod()));
-    logMethodValue.setVisible(StringUtils.isNotBlank(logEntry.getActionMethod()));
-
-    logAddressValue.setText(logEntry.getAddress());
-    logAddressLabel.setVisible(StringUtils.isNotBlank(logEntry.getAddress()));
-    logAddressValue.setVisible(StringUtils.isNotBlank(logEntry.getAddress()));
-
-    logDatetimeValue.setText(Humanize.formatDateTime(logEntry.getDatetime()));
-    logDatetimeLabel.setVisible(logEntry.getDatetime() != null);
-    logDatetimeValue.setVisible(logEntry.getDatetime() != null);
-
-    logDurationValue.setText(Humanize.durationMillisToShortDHMS(logEntry.getDuration()));
-
-    logRelatedObjectValue.setText(logEntry.getRelatedObjectID());
-    logRelatedObjectLabel.setVisible(StringUtils.isNotBlank(logEntry.getRelatedObjectID()));
-    logRelatedObjectValue.setVisible(StringUtils.isNotBlank(logEntry.getRelatedObjectID()));
-
-    logUsernameValue.setText(logEntry.getUsername());
-    logUsernameLabel.setVisible(StringUtils.isNotBlank(logEntry.getUsername()));
-    logUsernameValue.setVisible(StringUtils.isNotBlank(logEntry.getUsername()));
-
-    List<LogEntryParameter> parameters = logEntry.getParameters();
-
-    if (parameters != null && !parameters.isEmpty()) {
-      for (LogEntryParameter par : parameters) {
-        HTML parPanel = new HTML();
-        parPanel.setHTML(SafeHtmlUtils.fromString(messages.logParameter(par.getName(), par.getValue())));
-        logParametersValue.add(parPanel);
-      }
-      logParametersLabel.setVisible(true);
-      logParametersValue.setVisible(true);
-    } else {
-      logParametersLabel.setVisible(false);
-      logParametersValue.setVisible(false);
-    }
-
-    logStateValue.setHTML(HtmlSnippetUtils.getLogEntryStateHtml(logEntry.getState()));
-    logStateLabel.setVisible(logEntry.getState() != null);
-    logStateValue.setVisible(logEntry.getState() != null);
-
-    expandedAuditLogsList.setVisible(false);
+    actionsToolbar.setLabel(messages.showLogEntryTitle());
+    browseTab.init(logEntry);
+    title.setText(StringUtils.isNotBlank(logEntry.getId()) ? logEntry.getId() : logEntry.getUUID());
+    keyboardFocus.setFocus(true);
+    keyboardFocus.addStyleName("browse browse-file browse_main_panel");
 
     if (logEntry.getAuditLogRequestHeaders() != null) {
       Label relatedAuditLogs = new Label();
@@ -218,16 +130,17 @@ public class ShowLogEntry extends Composite {
       expandedAuditLogs.add(relatedAuditLogs);
 
       Filter filter = new Filter(new SimpleFilterParameter(RodaConstants.LOG_REQUEST_HEADER_UUID,
-        logEntry.getAuditLogRequestHeaders().getUuid()));
+              logEntry.getAuditLogRequestHeaders().getUuid()));
 
       ListBuilder<LogEntry> auditLogListBuilder = new ListBuilder<>(() -> new InternalLogEntryList(),
-        new AsyncTableCellOptions<>(LogEntry.class, "AuditLogs_triggeredLogs").withFilter(filter)
-          .withSummary(messages.listOfAIPs()).bindOpener());
+              new AsyncTableCellOptions<>(LogEntry.class, "AuditLogs_triggeredLogs").withFilter(filter)
+                      .withSummary(messages.listOfAIPs()).bindOpener());
 
       SearchWrapper aipsSearchWrapper = new SearchWrapper(false).createListAndSearchPanel(auditLogListBuilder);
       expandedAuditLogsList.setWidget(aipsSearchWrapper);
       expandedAuditLogsList.setVisible(true);
     }
+
   }
 
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowLogEntry.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/management/ShowLogEntry.ui.xml
@@ -1,97 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:g="urn:import:com.google.gwt.user.client.ui"
-	xmlns:common="urn:import:org.roda.wui.client.common">
+			 xmlns:common="urn:import:org.roda.wui.client.common"
+			 xmlns:tabs="urn:import:org.roda.wui.client.browse.tabs">
 
 	<ui:with field='messages' type='config.i18n.client.ClientMessages' />
 
-	<g:FlowPanel styleName="wui-management-user" addStyleNames="wrapper skip_padding">
-		<g:FlowPanel addStyleNames="row full_width skip_padding">
-			<g:FlowPanel addStyleNames="col_12 content">
-				<g:FlowPanel styleName="wui-user-data" addStyleNames="wrapper skip_padding">
-					<g:FlowPanel addStyleNames="row full_width no_padding">
-						<g:FlowPanel addStyleNames="wui-data-panel">
-							<common:TitlePanel text="{messages.showLogEntryTitle}" iconClass="LogEntry" />
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="logIdLabel">
-									<ui:text from='{messages.logEntryIdentifier}' />
-								</g:Label>
-								<g:Label styleName="value" ui:field="logIdValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="logReasonLabel">
-									<ui:text from='{messages.logEntryReason}' />
-								</g:Label>
-								<g:Label styleName="value" ui:field="logReasonValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="logInstanceIdLabel">
-									<ui:text from='{messages.logEntryInstanceId}' />
-								</g:Label>
-								<g:Label styleName="value" ui:field="logInstanceIdValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="logComponentLabel">
-									<ui:text from='{messages.logEntryComponent}' />
-								</g:Label>
-								<g:Label styleName="value" ui:field="logComponentValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="logMethodLabel">
-									<ui:text from='{messages.logEntryMethod}' />
-								</g:Label>
-								<g:Label styleName="value" ui:field="logMethodValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="logAddressLabel">
-									<ui:text from='{messages.logEntryAddress}' />
-								</g:Label>
-								<g:Label styleName="value" ui:field="logAddressValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="logDatetimeLabel">
-									<ui:text from='{messages.logEntryDatetime}' />
-								</g:Label>
-								<g:Label styleName="value" ui:field="logDatetimeValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="logDurationLabel">
-									<ui:text from='{messages.logEntryDuration}' />
-								</g:Label>
-								<g:Label styleName="value" ui:field="logDurationValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="logRelatedObjectLabel">
-									<ui:text from='{messages.logEntryRelatedObject}' />
-								</g:Label>
-								<g:Label styleName="value" ui:field="logRelatedObjectValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="logUsernameLabel">
-									<ui:text from='{messages.logEntryUsername}' />
-								</g:Label>
-								<g:Label styleName="value" ui:field="logUsernameValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="logParametersLabel">
-									<ui:text from='{messages.logEntryParameters}' />
-								</g:Label>
-								<g:FlowPanel styleName="value" ui:field="logParametersValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="logStateLabel">
-									<ui:text from='{messages.logEntryState}' />
-								</g:Label>
-								<g:HTML styleName="value" ui:field="logStateValue" />
-							</g:FlowPanel>
-							<g:FlowPanel>
-								<g:SimplePanel ui:field="expandedAuditLogs" />
-								<g:SimplePanel ui:field="expandedAuditLogsList" />
-							</g:FlowPanel>
-						</g:FlowPanel>
+	<g:FocusPanel ui:field="keyboardFocus">
+		<g:FlowPanel styleName="browse" addStyleNames="wrapper skip_padding">
+
+			<common:NavigationToolbar ui:field="navigationToolbar" />
+
+			<common:ActionsToolbar ui:field="actionsToolbar" />
+
+			<g:FlowPanel addStyleNames="row full_width skip_padding" ui:field="center">
+				<g:FlowPanel addStyleNames="col_12 content">
+
+					<common:TitlePanel ui:field="title" text="{messages.showLogEntryTitle}" iconClass="LogEntry" />
+					<tabs:BrowseLogEntryTabs ui:field="browseTab"/>
+					<g:FlowPanel>
+						<g:SimplePanel ui:field="expandedAuditLogs" />
+						<g:SimplePanel ui:field="expandedAuditLogsList" />
 					</g:FlowPanel>
 				</g:FlowPanel>
 			</g:FlowPanel>
 		</g:FlowPanel>
-	</g:FlowPanel>
+	</g:FocusPanel>
 </ui:UiBinder>


### PR DESCRIPTION
- created a new audit log details panel with a card-based layout aligned with the updated UI pattern
- introduced log-entry tabs (`BrowseLogEntryTabs`) and wired the details tab to render audit log metadata in the new `DetailsPanelLogEntry` panel
- added breadcrumb support for audit log details (Audit logs / <entry>) with `BreadcrumbUtils.getLogEntryBreadcrumbs(...)` to keep navigation consistent with other modernized pages
- refactored the page structure to use the same shell components for RODA 6 (navigation toolbar, actions toolbar, title, and tabs) without changing existing audit log behavior

resolves #3624 