### PR TITLE
New layout UI for Representation Information detailed page

### DIFF
--- a/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
+++ b/roda-ui/roda-wui/src/main/java/config/i18n/client/ClientMessages.java
@@ -1018,6 +1018,10 @@ public interface ClientMessages extends Messages {
 
   String detailsCreatedBy();
 
+  String detailsUpdatedOn();
+
+  String detailsUpdatedBy();
+
   String detailsModifiedOn();
 
   String detailsModifiedBy();
@@ -1322,10 +1326,15 @@ public interface ClientMessages extends Messages {
 
   String representationInformationIntellectualEntities(@PluralCount int size, String link);
 
+  String representationInformationIntellectualEntitiesAssociations();
+
   String representationInformationRepresentations(@PluralCount int size, String link);
+
+  String representationInformationRepresentationsAssociations();
 
   String representationInformationFiles(@PluralCount int size, String link);
 
+  String representationInformationFilesAssociations();
   /****** Descriptive Metadata ****/
 
   String metadataType();

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseRepresentationInformationTabs.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/BrowseRepresentationInformationTabs.java
@@ -1,0 +1,114 @@
+package org.roda.wui.client.browse.tabs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.utils.RepresentationInformationUtils;
+import org.roda.core.data.v2.index.IsIndexed;
+import org.roda.core.data.v2.index.filter.Filter;
+import org.roda.core.data.v2.index.filter.FilterParameter;
+import org.roda.core.data.v2.index.filter.OrFiltersParameters;
+import org.roda.core.data.v2.index.filter.SimpleFilterParameter;
+import org.roda.core.data.v2.ip.IndexedAIP;
+import org.roda.core.data.v2.ip.IndexedFile;
+import org.roda.core.data.v2.ip.IndexedRepresentation;
+import org.roda.core.data.v2.ri.RepresentationInformation;
+import org.roda.wui.client.common.lists.utils.AsyncTableCellOptions;
+import org.roda.wui.client.common.lists.utils.ConfigurableAsyncTableCell;
+import org.roda.wui.client.common.lists.utils.ListBuilder;
+import org.roda.wui.client.common.search.SearchWrapper;
+
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.SimplePanel;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ *
+ * @author Eduardo Teixeira <eteixeira@keep.pt>
+ */
+public class BrowseRepresentationInformationTabs extends Tabs {
+  public void init(RepresentationInformation ri) {
+
+    List<FilterParameter> aipParams = new ArrayList<>();
+    List<FilterParameter> representationParams = new ArrayList<>();
+    List<FilterParameter> fileParams = new ArrayList<>();
+    initEntityFilters(ri, aipParams, representationParams, fileParams);
+
+    createAndAddTab(SafeHtmlUtils.fromSafeConstant(messages.detailsTab()), new TabContentBuilder() {
+      @Override
+      public Widget buildTabWidget() {
+        return new DetailsTab(ri);
+      }
+    });
+
+    createAndAddTab(SafeHtmlUtils.fromString(messages.representationInformationIntellectualEntitiesAssociations()),
+      () -> buildAssociationsTab(IndexedAIP.class, aipParams, "Search_AIPs"));
+
+    createAndAddTab(SafeHtmlUtils.fromString(messages.representationInformationRepresentationsAssociations()),
+      () -> buildAssociationsTab(IndexedRepresentation.class, representationParams, "Search_representations"));
+
+    createAndAddTab(SafeHtmlUtils.fromString(messages.representationInformationFilesAssociations()),
+      () -> buildAssociationsTab(IndexedFile.class, fileParams, "Search_files"));
+  }
+
+  private void initEntityFilters(RepresentationInformation ri, List<FilterParameter> aipParams,
+    List<FilterParameter> representationParams, List<FilterParameter> fileParams) {
+    for (String filter : ri.getFilters()) {
+      String[] parts = filter.split(RepresentationInformationUtils.REPRESENTATION_INFORMATION_FILTER_SEPARATOR);
+      if (parts.length < 3) {
+        continue;
+      }
+
+      if (RodaConstants.INDEX_AIP.equals(parts[0])) {
+        aipParams.add(new SimpleFilterParameter(parts[1], parts[2]));
+      } else if (RodaConstants.INDEX_REPRESENTATION.equals(parts[0])) {
+        representationParams.add(new SimpleFilterParameter(parts[1], parts[2]));
+      } else if (RodaConstants.INDEX_FILE.equals(parts[0])) {
+        fileParams.add(new SimpleFilterParameter(parts[1], parts[2]));
+      }
+    }
+  }
+
+  private <T extends IsIndexed> Widget buildAssociationsTab(Class<T> clazz, List<FilterParameter> params,
+    String listId) {
+
+    if (params == null || params.isEmpty()) {
+      if (IndexedAIP.class.equals(clazz)) {
+        return buildEmptyAssociationsCardLikeTab(messages.representationInformationIntellectualEntities(0, ""));
+      }
+      if (IndexedRepresentation.class.equals(clazz)) {
+        return buildEmptyAssociationsCardLikeTab(messages.representationInformationRepresentations(0, ""));
+      }
+      return buildEmptyAssociationsCardLikeTab(messages.representationInformationFiles(0, ""));
+    }
+    Filter filter = new Filter(new OrFiltersParameters(params));
+
+    ListBuilder<T> listBuilder = new ListBuilder<>(() -> new ConfigurableAsyncTableCell<>(),
+      new AsyncTableCellOptions<>(clazz, listId).withFilter(filter).withJustActive(false).bindOpener());
+
+    return new SearchWrapper(false).createListAndSearchPanel(listBuilder);
+  }
+
+  private Widget buildEmptyAssociationsCardLikeTab(String messageHtml) {
+    FlowPanel card = new FlowPanel();
+    card.addStyleName("roda6CardWithHeader");
+    card.addStyleName("wrapper");
+    card.addStyleName("skip_padding");
+
+    FlowPanel body = new FlowPanel();
+    body.addStyleName("cardBody");
+
+    SimplePanel info = new SimplePanel();
+    info.addStyleName("table-empty-inner");
+    HTML label = new HTML(messageHtml);
+    label.addStyleName("table-empty-inner-label");
+    info.setWidget(label);
+
+    body.add(info);
+    card.add(body);
+    return card;
+  }
+}

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/DetailsTab.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/browse/tabs/DetailsTab.java
@@ -11,10 +11,12 @@ import java.util.List;
 
 import org.roda.core.data.v2.ip.IndexedFile;
 import org.roda.core.data.v2.ip.TransferredResource;
+import org.roda.core.data.v2.ri.RepresentationInformation;
 import org.roda.core.data.v2.notifications.Notification;
 import org.roda.core.data.v2.log.LogEntry;
 import org.roda.wui.client.common.model.BrowseAIPResponse;
 import org.roda.wui.client.common.model.BrowseRepresentationResponse;
+import org.roda.wui.client.planning.DetailsPanelRepresentationInformation;
 import org.roda.wui.client.management.DetailsPanelNotification;
 import org.roda.wui.client.management.DetailsPanelLogEntry;
 import org.roda.wui.client.ingest.transfer.DetailsPanelTransferredResource;
@@ -59,6 +61,13 @@ public class DetailsTab extends Composite {
     initWidget(uiBinder.createAndBindUi(this));
     // Get metadata and populate widget
     DetailsPanelFile detailsPanel = new DetailsPanelFile(file, riRules);
+    content.add(detailsPanel);
+  }
+
+  public DetailsTab(RepresentationInformation ri){
+    initWidget(uiBinder.createAndBindUi(this));
+
+    DetailsPanelRepresentationInformation detailsPanel = new DetailsPanelRepresentationInformation(ri);
     content.add(detailsPanel);
   }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseRepresentationInformationActionsToolbar.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/BrowseRepresentationInformationActionsToolbar.java
@@ -1,0 +1,33 @@
+package org.roda.wui.client.common;
+
+import java.util.List;
+
+import org.roda.core.data.v2.ri.RepresentationInformation;
+import org.roda.wui.client.common.actions.RepresentationInformationActions;
+import org.roda.wui.client.common.actions.model.ActionableObject;
+import org.roda.wui.client.common.actions.widgets.ActionableWidgetBuilder;
+
+/**
+ *
+ * @author Eduardo Teixeira <eteixeira@keep.pt>
+ */
+public class BrowseRepresentationInformationActionsToolbar
+  extends BrowseObjectActionsToolbar<RepresentationInformation> {
+  public void buildIcon() {
+    setIcon(null);
+  }
+
+  public void buildTags() {
+    // do nothing
+  }
+
+  public void buildActions() {
+    this.actions.clear();
+    RepresentationInformationActions representationInformationActions;
+    representationInformationActions = RepresentationInformationActions.get();
+    this.actions.add(new ActionableWidgetBuilder<RepresentationInformation>(representationInformationActions)
+      .buildGroupedListWithObjects(new ActionableObject<>(object), List.of(),
+        List.of(RepresentationInformationActions.RepresentationInformationAction.START_PROCESS)));
+  }
+
+}

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RepresentationInformationActions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/actions/RepresentationInformationActions.java
@@ -45,8 +45,6 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 
 import config.i18n.client.ClientMessages;
 
-import javax.naming.Context;
-
 public class RepresentationInformationActions extends AbstractActionable<RepresentationInformation> {
   private static final RepresentationInformationActions INSTANCE = new RepresentationInformationActions();
   private static final ClientMessages messages = GWT.create(ClientMessages.class);
@@ -328,7 +326,7 @@ public class RepresentationInformationActions extends AbstractActionable<Represe
     ActionableBundle<RepresentationInformation> formatActionableBundle = new ActionableBundle<>();
 
     // MANAGEMENT
-    ActionableGroup<RepresentationInformation> managementGroup = new ActionableGroup<>(messages.sidebarActionsTitle());
+    ActionableGroup<RepresentationInformation> managementGroup = new ActionableGroup<>(messages.manage(), "btn-edit");
     managementGroup.addButton(messages.newButton(), RepresentationInformationAction.NEW, ActionImpact.UPDATED,
       "btn-plus-circle");
     managementGroup.addButton(messages.createNewRepresentationInformation(),

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -2581,6 +2581,7 @@ td.datePickerMonth, td.datePickerYear {
 .main .wui-breadcrumbPanel .breadcrumb-root {
     color: COLOR_PRIMARY;
     font-weight: bold;
+    max-width: none !important;
 }
 
 .main .wui-breadcrumbPanel .breadcrumb-last {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/BreadcrumbUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/main/BreadcrumbUtils.java
@@ -21,6 +21,7 @@ import org.roda.core.data.v2.ip.IndexedRepresentation;
 import org.roda.core.data.v2.ip.TransferredResource;
 import org.roda.core.data.v2.user.RODAMember;
 import org.roda.core.data.v2.log.LogEntry;
+import org.roda.core.data.v2.ri.RepresentationInformation;
 import org.roda.wui.client.browse.BrowseTop;
 import org.roda.wui.client.management.ShowLogEntry;
 import org.roda.wui.client.management.UserLog;
@@ -30,6 +31,8 @@ import org.roda.wui.client.ingest.appraisal.IngestAppraisal;
 import org.roda.wui.client.ingest.transfer.IngestTransfer;
 import org.roda.wui.client.management.members.MemberManagement;
 import org.roda.wui.client.management.members.ShowMember;
+import org.roda.wui.client.planning.RepresentationInformationNetwork;
+import org.roda.wui.client.planning.ShowRepresentationInformation;
 import org.roda.wui.common.client.tools.DescriptionLevelUtils;
 import org.roda.wui.common.client.tools.HistoryUtils;
 import org.roda.wui.common.client.tools.ListUtils;
@@ -383,6 +386,23 @@ public class BreadcrumbUtils {
       List<String> path = new ArrayList<>(ShowNotification.RESOLVER.getHistoryPath());
       path.add(notification.getUUID());
       String label = StringUtils.isNotBlank(notification.getId()) ? notification.getId() : notification.getUUID();
+      ret.add(new BreadcrumbItem(SafeHtmlUtils.fromString(label), label, path));
+    }
+
+    return ret;
+  }
+
+  public static List<BreadcrumbItem> getRepresentationInformationBreadCrumbs(RepresentationInformation ri){
+    List<BreadcrumbItem> ret = new ArrayList<>();
+    ret.add(new BreadcrumbItem(
+            SafeHtmlUtils.fromSafeConstant(messages.representationInformationTitle()),
+            messages.representationInformationTitle(),
+            RepresentationInformationNetwork.RESOLVER.getHistoryPath()));
+
+    if (ri != null) {
+      List<String> path = new ArrayList<>(ShowRepresentationInformation.RESOLVER.getHistoryPath());
+      path.add(ri.getUUID());
+      String label = ri.getName() != null ? ri.getName() : ri.getId();
       ret.add(new BreadcrumbItem(SafeHtmlUtils.fromString(label), label, path));
     }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/DetailsPanelRepresentationInformation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/DetailsPanelRepresentationInformation.java
@@ -1,0 +1,189 @@
+package org.roda.wui.client.planning;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.roda.core.data.common.RodaConstants;
+import org.roda.core.data.v2.ri.RelationObjectType;
+import org.roda.core.data.v2.ri.RepresentationInformation;
+import org.roda.core.data.v2.ri.RepresentationInformationRelation;
+import org.roda.wui.client.common.utils.HtmlSnippetUtils;
+import org.roda.wui.client.search.Search;
+import org.roda.wui.client.services.Services;
+import org.roda.wui.common.client.tools.HistoryUtils;
+import org.roda.wui.common.client.tools.Humanize;
+import org.roda.wui.common.client.tools.StringUtils;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.i18n.client.LocaleInfo;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Anchor;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.InlineHTML;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+
+import config.i18n.client.ClientMessages;
+
+/**
+ *
+ * @author Eduardo Teixeira <eteixeira@keep.pt>
+ */
+public class DetailsPanelRepresentationInformation extends Composite {
+  private static final ClientMessages messages = GWT.create(ClientMessages.class);
+  private static final MyUiBinder uiBinder = GWT.create(MyUiBinder.class);
+
+  @UiField
+  FlowPanel details;
+
+  public DetailsPanelRepresentationInformation(RepresentationInformation ri) {
+    initWidget(uiBinder.createAndBindUi(this));
+    init(ri);
+  }
+
+  private void init(RepresentationInformation ri) {
+    if (ri.getCreatedOn() != null && StringUtils.isNotBlank(ri.getCreatedBy())) {
+      addIfNotBlank(messages.detailsCreatedOn(), Humanize.formatDateTime(ri.getCreatedOn()));
+      addIfNotBlank(messages.detailsCreatedBy(), ri.getCreatedBy());
+    }
+
+    if (ri.getUpdatedOn() != null && StringUtils.isNotBlank(ri.getUpdatedBy())) {
+      addIfNotBlank(messages.detailsUpdatedOn(), Humanize.formatDateTime(ri.getUpdatedOn()));
+      addIfNotBlank(messages.detailsUpdatedBy(), ri.getUpdatedBy());
+    }
+    addIfNotBlank(messages.representationInformationIdentifier(), ri.getId());
+    addIfNotBlank(messages.representationInformationName(), ri.getName());
+    addIfNotBlank(messages.representationInformationDescription(), ri.getDescription());
+    addIfNotBlank(messages.representationInformationFamily(), ri.getFamilyI18n());
+
+    if (ri.getSupport() != null) {
+      addIfNotBlank(messages.representationInformationSupport(),
+        messages.representationInformationSupportValue(ri.getSupport().toString()));
+    }
+
+    addTagsField(ri);
+    addExtrasField(ri);
+    initRelations(ri);
+
+  }
+
+  private void addIfNotBlank(String label, String value) {
+    if (StringUtils.isNotBlank(value)) {
+      details.add(buildField(label, new InlineHTML(SafeHtmlUtils.htmlEscape(value))));
+    }
+  }
+
+  private Widget buildField(String label, Widget valueWidget) {
+    FlowPanel fieldPanel = new FlowPanel();
+    fieldPanel.setStyleName("field");
+
+    Label fieldLabel = new Label(label);
+    fieldLabel.setStyleName("label");
+
+    FlowPanel fieldValuePanel = new FlowPanel();
+    fieldValuePanel.setStyleName("value");
+    fieldValuePanel.add(valueWidget);
+
+    fieldPanel.add(fieldLabel);
+    fieldPanel.add(fieldValuePanel);
+
+    return fieldPanel;
+  }
+
+  private void addTagsField(RepresentationInformation ri) {
+    List<String> tags = ri.getTags();
+    if (tags == null || tags.isEmpty())
+      return;
+
+    FlowPanel tagsPanel = new FlowPanel();
+    tagsPanel.addStyleName("value");
+    for (String category : tags) {
+      InlineHTML tag = new InlineHTML("<span class='label-info btn-separator-right ri-category'>"
+        + messages.representationInformationListItems(SafeHtmlUtils.htmlEscape(category)) + "</span>");
+      tag.addClickHandler(event -> {
+        List<String> history = new ArrayList<>(RepresentationInformationNetwork.RESOLVER.getHistoryPath());
+        history.add(Search.RESOLVER.getHistoryToken());
+        history.add(RodaConstants.REPRESENTATION_INFORMATION_TAGS);
+        history.add(category);
+        HistoryUtils.newHistory(history);
+      });
+      tagsPanel.add(tag);
+    }
+
+    details.add(buildField(messages.representationInformationTags(), tagsPanel));
+  }
+
+  private void addExtrasField(RepresentationInformation ri) {
+    Services services = new Services("Retrieve representation information family metadata", "get");
+    services
+      .representationInformationResource(
+        s -> s.retrieveRepresentationInformationFamily(ri.getId(), LocaleInfo.getCurrentLocale().getLocaleName()))
+      .whenComplete((family, throwable) -> {
+        if (throwable == null && family != null && family.getFamilyValues() != null
+          && !family.getFamilyValues().isEmpty()) {
+
+          FlowPanel extrasContent = new FlowPanel();
+          extrasContent.addStyleName("ri-extras-panel");
+
+          HtmlSnippetUtils.createExtraShow(extrasContent, family.getFamilyValues(), false);
+
+          if (extrasContent.getWidgetCount() > 0) {
+            details.add(extrasContent);
+          }
+        }
+      });
+  }
+
+  private void initRelations(RepresentationInformation ri) {
+    if (ri.getRelations() == null) {
+      return;
+    }
+
+    ri.getRelations().sort(Comparator.comparingInt(o -> o.getObjectType().getWeight()));
+    for (RepresentationInformationRelation relation : ri.getRelations()) {
+      Widget relationValue = createRelationViewer(relation);
+      if (relationValue != null) {
+        relationValue.addStyleName("ri-links-panel");
+        details.add(buildField(relation.getRelationTypeI18n(), relationValue));
+      }
+    }
+  }
+
+  private Widget createRelationViewer(RepresentationInformationRelation relation) {
+    Widget widgetToAdd = null;
+    String title = StringUtils.isNotBlank(relation.getTitle()) ? relation.getTitle() : relation.getLink();
+
+    if (relation.getObjectType().equals(RelationObjectType.TEXT)) {
+      widgetToAdd = new Label(title);
+    } else {
+      Anchor anchor = null;
+
+      if (relation.getObjectType().equals(RelationObjectType.AIP)) {
+        anchor = new Anchor(title,
+          HistoryUtils.createHistoryHashLink(HistoryUtils.getHistoryBrowse(relation.getLink())));
+      } else if (relation.getObjectType().equals(RelationObjectType.REPRESENTATION_INFORMATION)) {
+        List<String> history = new ArrayList<>();
+        history.addAll(ShowRepresentationInformation.RESOLVER.getHistoryPath());
+        history.add(relation.getLink());
+        anchor = new Anchor(title, HistoryUtils.createHistoryHashLink(history));
+      } else if (relation.getObjectType().equals(RelationObjectType.WEB)) {
+        anchor = new Anchor(title, relation.getLink());
+        anchor.getElement().setAttribute("target", "_blank");
+      }
+
+      if (anchor != null) {
+        widgetToAdd = anchor;
+      }
+    }
+
+    return widgetToAdd;
+  }
+
+  interface MyUiBinder extends UiBinder<Widget, DetailsPanelRepresentationInformation> {
+    Widget createAndBindUi(DetailsPanelRepresentationInformation representationInformationPanel);
+  }
+}

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/DetailsPanelRepresentationInformation.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/DetailsPanelRepresentationInformation.ui.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+             xmlns:g="urn:import:com.google.gwt.user.client.ui">
+
+    <g:FlowPanel addStyleNames="descriptiveMetadataHTML">
+        <g:FlowPanel ui:field="details" addStyleNames="descriptiveMetadata"/>
+    </g:FlowPanel>
+</ui:UiBinder>

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/ShowRepresentationInformation.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/ShowRepresentationInformation.java
@@ -10,58 +10,27 @@
  */
 package org.roda.wui.client.planning;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
-import org.roda.core.data.common.RodaConstants;
-import org.roda.core.data.utils.RepresentationInformationUtils;
-import org.roda.core.data.v2.index.CountRequest;
-import org.roda.core.data.v2.index.filter.Filter;
-import org.roda.core.data.v2.index.filter.FilterParameter;
-import org.roda.core.data.v2.index.filter.OrFiltersParameters;
-import org.roda.core.data.v2.index.filter.SimpleFilterParameter;
-import org.roda.core.data.v2.ip.IndexedAIP;
-import org.roda.core.data.v2.ip.IndexedFile;
-import org.roda.core.data.v2.ip.IndexedRepresentation;
-import org.roda.core.data.v2.ri.RelationObjectType;
 import org.roda.core.data.v2.ri.RepresentationInformation;
-import org.roda.core.data.v2.ri.RepresentationInformationCreateRequest;
-import org.roda.core.data.v2.ri.RepresentationInformationRelation;
-import org.roda.wui.client.common.NoAsyncCallback;
+import org.roda.wui.client.browse.tabs.BrowseRepresentationInformationTabs;
+import org.roda.wui.client.common.BrowseRepresentationInformationActionsToolbar;
+import org.roda.wui.client.common.NavigationToolbar;
 import org.roda.wui.client.common.TitlePanel;
 import org.roda.wui.client.common.UserLogin;
-import org.roda.wui.client.common.actions.Actionable;
-import org.roda.wui.client.common.actions.RepresentationInformationActions;
-import org.roda.wui.client.common.actions.model.ActionableObject;
-import org.roda.wui.client.common.actions.widgets.ActionableWidgetBuilder;
-import org.roda.wui.client.common.dialogs.RepresentationInformationDialogs;
-import org.roda.wui.client.common.utils.AsyncCallbackUtils;
-import org.roda.wui.client.common.utils.HtmlSnippetUtils;
-import org.roda.wui.client.common.utils.SidebarUtils;
-import org.roda.wui.client.search.Search;
+import org.roda.wui.client.main.BreadcrumbUtils;
 import org.roda.wui.client.services.Services;
 import org.roda.wui.common.client.HistoryResolver;
 import org.roda.wui.common.client.tools.HistoryUtils;
-import org.roda.wui.common.client.tools.Humanize;
 import org.roda.wui.common.client.tools.ListUtils;
-import org.roda.wui.common.client.tools.StringUtils;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.i18n.client.LocaleInfo;
-import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HTML;
-import com.google.gwt.user.client.ui.InlineHTML;
-import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.SimplePanel;
+import com.google.gwt.user.client.ui.FocusPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 import config.i18n.client.ClientMessages;
@@ -100,49 +69,21 @@ public class ShowRepresentationInformation extends Composite {
   private static MyUiBinder uiBinder = GWT.create(MyUiBinder.class);
 
   @UiField
-  Label representationInformationId;
+  NavigationToolbar<RepresentationInformation> navigationToolbar;
+
   @UiField
-  Label dateCreated;
+  BrowseRepresentationInformationActionsToolbar actionsToolbar;
+
   @UiField
-  Label dateUpdated;
+  FocusPanel keyboardFocus;
+
   @UiField
   TitlePanel title;
+
   @UiField
-  Label representationInformationDescriptionKey;
-  @UiField
-  HTML representationInformationDescriptionValue;
-  @UiField
-  Label representationInformationFamilyKey;
-  @UiField
-  Label representationInformationFamilyValue;
-  @UiField
-  Label representationInformationTagKey;
-  @UiField
-  FlowPanel representationInformationTagValue;
-  @UiField
-  Label representationInformationSupportKey;
-  @UiField
-  Label representationInformationSupportValue;
-  @UiField
-  FlowPanel representationInformationRelationsValue;
-  @UiField
-  FlowPanel objectPanel;
-  @UiField
-  FlowPanel additionalSeparator;
-  @UiField
-  FlowPanel extras;
-  @UiField
-  SimplePanel actionsSidebar;
-  @UiField
-  FlowPanel contentFlowPanel;
-  @UiField
-  FlowPanel sidebarFlowPanel;
+  BrowseRepresentationInformationTabs browseRepresentationInformationTabs;
 
   private RepresentationInformation ri;
-  private ActionableWidgetBuilder<RepresentationInformation> actionableWidgetBuilder;
-  private List<FilterParameter> aipParams = new ArrayList<>();
-  private List<FilterParameter> representationParams = new ArrayList<>();
-  private List<FilterParameter> fileParams = new ArrayList<>();
 
   public ShowRepresentationInformation() {
     this.ri = new RepresentationInformation();
@@ -153,9 +94,17 @@ public class ShowRepresentationInformation extends Composite {
     this.ri = ri;
 
     initWidget(uiBinder.createAndBindUi(this));
-    initEntityFilters();
-    objectPanel.addStyleName("ri-entity-relation-section");
-    initElements();
+
+    navigationToolbar.withoutButtons().build();
+    navigationToolbar.updateBreadcrumbPath(BreadcrumbUtils.getRepresentationInformationBreadCrumbs(ri));
+
+    title.setText(ri.getName());
+
+    actionsToolbar.setObjectAndBuild(ri, null, null);
+    browseRepresentationInformationTabs.init(ri);
+
+    keyboardFocus.setFocus(true);
+    keyboardFocus.addStyleName("browse browse-file browse_main_panel");
   }
 
   public static ShowRepresentationInformation getInstance() {
@@ -164,256 +113,6 @@ public class ShowRepresentationInformation extends Composite {
     }
     return instance;
   }
-
-  public void initElements() {
-    title.setText(ri.getName());
-
-    representationInformationId.setText(messages.representationInformationIdentifier() + ": " + ri.getId());
-
-    if (ri.getCreatedOn() != null && StringUtils.isNotBlank(ri.getCreatedBy())) {
-      dateCreated.setText(messages.dateCreated(Humanize.formatDateTime(ri.getCreatedOn()), ri.getCreatedBy()));
-    }
-
-    if (ri.getUpdatedOn() != null && StringUtils.isNotBlank(ri.getUpdatedBy())) {
-      dateUpdated.setText(messages.dateUpdated(Humanize.formatDateTime(ri.getUpdatedOn()), ri.getUpdatedBy()));
-    }
-
-    String description = (ri.getDescription() == null) ? "" : ri.getDescription();
-    representationInformationDescriptionValue.setHTML(SafeHtmlUtils.fromString(description));
-    representationInformationDescriptionKey.setVisible(StringUtils.isNotBlank(ri.getDescription()));
-
-    representationInformationFamilyKey.setVisible(StringUtils.isNotBlank(ri.getFamily()));
-    representationInformationFamilyValue.setText(ri.getFamilyI18n());
-
-    List<String> tagsList = ri.getTags();
-    representationInformationTagValue.setVisible(tagsList != null && !tagsList.isEmpty());
-    representationInformationTagKey.setVisible(tagsList != null && !tagsList.isEmpty());
-
-    if (tagsList != null) {
-      for (final String category : tagsList) {
-        InlineHTML parPanel = new InlineHTML();
-        parPanel.setHTML("<span class='label label-info btn-separator-right ri-category'>"
-          + messages.representationInformationListItems(SafeHtmlUtils.htmlEscape(category)) + "</span>");
-        parPanel.addClickHandler(event -> {
-          List<String> history = new ArrayList<>(RepresentationInformationNetwork.RESOLVER.getHistoryPath());
-          history.add(Search.RESOLVER.getHistoryToken());
-          history.add(RodaConstants.REPRESENTATION_INFORMATION_TAGS);
-          history.add(category);
-          HistoryUtils.newHistory(history);
-        });
-        representationInformationTagValue.add(parPanel);
-      }
-    }
-
-    if (ri.getSupport() != null) {
-      representationInformationSupportValue
-        .setText(messages.representationInformationSupportValue(ri.getSupport().toString()));
-      representationInformationSupportKey.setVisible(true);
-    } else {
-      representationInformationSupportKey.setVisible(false);
-    }
-
-    Services services = new Services("Retrieve representation information family metadata", "get");
-    services
-      .representationInformationResource(
-        s -> s.retrieveRepresentationInformationFamily(ri.getId(), LocaleInfo.getCurrentLocale().getLocaleName()))
-      .whenComplete((representationInformationFamily, throwable) -> {
-        if (throwable == null) {
-          HtmlSnippetUtils.createExtraShow(extras, representationInformationFamily.getFamilyValues(), false);
-        }
-      });
-
-    RepresentationInformationActions representationInformationActions = RepresentationInformationActions.get();
-
-    actionableWidgetBuilder = new ActionableWidgetBuilder<>(representationInformationActions)
-      .withActionCallback(new NoAsyncCallback<Actionable.ActionImpact>() {
-        @Override
-        public void onSuccess(Actionable.ActionImpact result) {
-          if (result.equals(Actionable.ActionImpact.DESTROYED)) {
-            HistoryUtils.newHistory(RepresentationInformationNetwork.RESOLVER);
-          }
-        }
-      });
-
-    SidebarUtils.toggleSidebar(contentFlowPanel, sidebarFlowPanel, representationInformationActions.hasAnyRoles());
-    actionsSidebar.setWidget(actionableWidgetBuilder.buildListWithObjects(new ActionableObject<>(ri)));
-
-    initRelations();
-  }
-
-  public void updateLists() {
-    aipParams.clear();
-    representationParams.clear();
-    fileParams.clear();
-
-    initEntityFilters();
-    initRelations();
-  }
-
-  private void initEntityFilters() {
-    for (String filter : ri.getFilters()) {
-      String[] splittedFilter = filter
-        .split(RepresentationInformationUtils.REPRESENTATION_INFORMATION_FILTER_SEPARATOR);
-
-      if (splittedFilter[0].equals(RodaConstants.INDEX_AIP)) {
-        aipParams.add(new SimpleFilterParameter(splittedFilter[1], splittedFilter[2]));
-      } else if (splittedFilter[0].equals(RodaConstants.INDEX_REPRESENTATION)) {
-        representationParams.add(new SimpleFilterParameter(splittedFilter[1], splittedFilter[2]));
-      } else if (splittedFilter[0].equals(RodaConstants.INDEX_FILE)) {
-        fileParams.add(new SimpleFilterParameter(splittedFilter[1], splittedFilter[2]));
-      }
-    }
-
-    if (!aipParams.isEmpty()) {
-      Filter aipFilter = new Filter();
-      aipFilter.add(new OrFiltersParameters(aipParams));
-      Services services = new Services("Count AIPs associated with representation information", "count");
-      CountRequest countRequest = new CountRequest(aipFilter, true);
-      services.rodaEntityRestService(s -> s.count(countRequest), IndexedAIP.class).whenComplete((count,
-        throwable) -> initEntityFiltersObjectPanel(count.getResult(), throwable, IndexedAIP.class.getSimpleName()));
-    } else if (!representationParams.isEmpty()) {
-      Filter representationFilter = new Filter();
-      representationFilter.add(new OrFiltersParameters(representationParams));
-
-      Services services = new Services("Count Representations associated with representation information", "count");
-      CountRequest countRequest = new CountRequest(representationFilter, true);
-      services.rodaEntityRestService(s -> s.count(countRequest), IndexedRepresentation.class)
-        .whenComplete((count, throwable) -> initEntityFiltersObjectPanel(count.getResult(), throwable,
-          IndexedRepresentation.class.getSimpleName()));
-    } else if (!fileParams.isEmpty()) {
-      Filter fileFilter = new Filter();
-      fileFilter.add(new OrFiltersParameters(fileParams));
-
-      Services services = new Services("Count Files associated with representation information", "count");
-      CountRequest countRequest = new CountRequest(fileFilter, true);
-      services.rodaEntityRestService(s -> s.count(countRequest), IndexedFile.class).whenComplete((count,
-        throwable) -> initEntityFiltersObjectPanel(count.getResult(), throwable, IndexedFile.class.getSimpleName()));
-    } else {
-      initEntityFiltersObjectPanel(0L, null, IndexedAIP.class.getSimpleName());
-    }
-  }
-
-  private void initEntityFiltersObjectPanel(final Long count, final Throwable throwable, final String searchType) {
-    if (throwable != null) {
-      AsyncCallbackUtils.defaultFailureTreatment(throwable);
-    } else {
-      ShowRepresentationInformation.this.objectPanel.clear();
-      String url = HistoryUtils.getSearchHistoryByRepresentationInformationFilter(
-        ShowRepresentationInformation.this.ri.getFilters(), searchType);
-
-      InlineHTML label = new InlineHTML();
-      label.addStyleName("ri-form-label-inline");
-      if (IndexedAIP.class.getSimpleName().equals(searchType)) {
-        label.setHTML(messages.representationInformationIntellectualEntities(count.intValue(), url));
-      } else if (IndexedRepresentation.class.getSimpleName().equals(searchType)) {
-        label.setHTML(messages.representationInformationRepresentations(count.intValue(), url));
-      } else if (IndexedFile.class.getSimpleName().equals(searchType)) {
-        label.setHTML(messages.representationInformationFiles(count.intValue(), url));
-      }
-
-      ShowRepresentationInformation.this.objectPanel.add(label);
-
-      InlineHTML edit = new InlineHTML("<i class='fa fa-pencil' aria-hidden='true'></i>");
-      edit.setTitle("Edit association rules");
-      edit.addStyleName("ri-category link-color");
-
-      edit.addClickHandler(new ClickHandler() {
-        @Override
-        public void onClick(ClickEvent event) {
-          RepresentationInformationDialogs.showPromptDialogRepresentationInformation(
-            messages.representationInformationEditAssociations(), messages.cancelButton(), messages.confirmButton(),
-            messages.searchButton(), ShowRepresentationInformation.this.ri,
-            new AsyncCallback<RepresentationInformation>() {
-              @Override
-              public void onFailure(Throwable caught) {
-                // do nothing
-              }
-
-              @Override
-              public void onSuccess(RepresentationInformation result) {
-                // result is ri with updated filters
-                Services services = new Services("Update representation information", "update");
-                RepresentationInformationCreateRequest createRequest = new RepresentationInformationCreateRequest();
-                createRequest.setRepresentationInformation(result);
-                services.representationInformationResource(s -> s.updateRepresentationInformation(createRequest))
-                  .whenComplete((representationInformation, throwable1) -> {
-                    if (throwable1 == null) {
-                      ShowRepresentationInformation.getInstance().updateLists();
-                    }
-                  });
-              }
-            });
-        }
-      });
-
-      ShowRepresentationInformation.this.objectPanel.add(edit);
-    }
-  }
-
-  private void initRelations() {
-    additionalSeparator.setVisible(!ri.getRelations().isEmpty());
-
-    ri.getRelations().sort(Comparator.comparingInt(o -> o.getObjectType().getWeight()));
-
-    for (RepresentationInformationRelation relation : ri.getRelations()) {
-      representationInformationRelationsValue.add(createRelationsLayout(relation));
-    }
-  }
-
-  private FlowPanel createRelationsLayout(RepresentationInformationRelation relation) {
-    FlowPanel panel = new FlowPanel();
-    FlowPanel linksPanel = new FlowPanel();
-
-    Label entryLabel = new Label(relation.getRelationTypeI18n());
-    entryLabel.setStyleName("label");
-    panel.add(entryLabel);
-
-    Widget w = createRelationViewer(relation);
-    if (w != null) {
-      w.addStyleName("ri-links-panel");
-      linksPanel.add(w);
-    }
-
-    panel.add(w);
-
-    return panel;
-  }
-
-  private Widget createRelationViewer(RepresentationInformationRelation relation) {
-    Widget widgetToAdd = null;
-    String title = StringUtils.isNotBlank(relation.getTitle()) ? relation.getTitle() : relation.getLink();
-
-    if (relation.getObjectType().equals(RelationObjectType.TEXT)) {
-      widgetToAdd = new Label(title);
-    } else {
-      Anchor anchor = null;
-
-      if (relation.getObjectType().equals(RelationObjectType.AIP)) {
-        anchor = new Anchor(title,
-          HistoryUtils.createHistoryHashLink(HistoryUtils.getHistoryBrowse(relation.getLink())));
-      } else if (relation.getObjectType().equals(RelationObjectType.REPRESENTATION_INFORMATION)) {
-        List<String> history = new ArrayList<>();
-        history.addAll(ShowRepresentationInformation.RESOLVER.getHistoryPath());
-        history.add(relation.getLink());
-        anchor = new Anchor(title, HistoryUtils.createHistoryHashLink(history));
-      } else if (relation.getObjectType().equals(RelationObjectType.WEB)) {
-        anchor = new Anchor(title, relation.getLink());
-        anchor.getElement().setAttribute("target", "_blank");
-      }
-
-      if (anchor != null) {
-        widgetToAdd = anchor;
-      }
-    }
-
-    return widgetToAdd;
-  }
-
-  // Java method
-  public native boolean isValidUrl(String url) /*-{
-		var pattern = /(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
-		return pattern.test(url);
-  }-*/;
 
   void resolve(List<String> historyTokens, final AsyncCallback<Widget> callback) {
     if (historyTokens.size() == 1) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/ShowRepresentationInformation.ui.xml
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/planning/ShowRepresentationInformation.ui.xml
@@ -1,78 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:g="urn:import:com.google.gwt.user.client.ui"
-	xmlns:common="urn:import:org.roda.wui.client.common">
+             xmlns:common="urn:import:org.roda.wui.client.common"
+             xmlns:tabs="urn:import:org.roda.wui.client.browse.tabs">
 
-	<ui:with field='messages' type='config.i18n.client.ClientMessages' />
+    <ui:with field='messages' type='config.i18n.client.ClientMessages'/>
 
-	<g:FlowPanel styleName="wui-management-user" addStyleNames="wrapper skip_padding">
-		<g:FlowPanel addStyleNames="row full_width skip_padding">
-			<g:FlowPanel addStyleNames="col_10 content" ui:field="contentFlowPanel">
-				<g:FlowPanel styleName="wui-user-data" addStyleNames="wrapper skip_padding">
-					<g:FlowPanel addStyleNames="row full_width no_padding">
-						<g:FlowPanel addStyleNames="wui-data-panel">
-							<g:FlowPanel styleName="browseItemPanelWithMargin">
-								<g:Label addStyleNames="browseItemHeader" ui:field="browseItemHeader">
-									<ui:text from='{messages.showRepresentationInformationTitle}' />
-								</g:Label>
-								<common:TitlePanel icon="fa fa-info-circle" ui:field="title" />
-								<g:Label addStyleNames="browseItemId" ui:field="representationInformationId"
-									title="{messages.representationInformationIdentifier}" />
-								<g:Label addStyleNames="browseItemId" ui:field="dateCreated" />
-								<g:Label addStyleNames="browseItemId" ui:field="dateUpdated" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="representationInformationDescriptionKey">
-									<ui:text from='{messages.representationInformationDescription}' />
-								</g:Label>
-								<g:HTML styleName="value ri-description"
-									ui:field="representationInformationDescriptionValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="representationInformationTagKey">
-									<ui:text from='{messages.representationInformationTags}' />
-								</g:Label>
-								<g:FlowPanel styleName="value" ui:field="representationInformationTagValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="representationInformationSupportKey">
-									<ui:text from='{messages.representationInformationSupport}' />
-								</g:Label>
-								<g:Label styleName="value" ui:field="representationInformationSupportValue" />
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:Label styleName="label" ui:field="representationInformationFamilyKey">
-									<ui:text from='{messages.representationInformationFamily}' />
-								</g:Label>
-								<g:Label styleName="value" ui:field="representationInformationFamilyValue" />
-							</g:FlowPanel>
-
-							<g:FlowPanel ui:field="extras">
-							</g:FlowPanel>
-
-							<g:FlowPanel styleName="ri-form-separator" ui:field="additionalSeparator">
-								<g:Label>
-									<ui:text from='{messages.representationInformationAdditionalInformation}' />
-								</g:Label>
-							</g:FlowPanel>
-							<g:FlowPanel styleName="field">
-								<g:FlowPanel styleName="value" ui:field="representationInformationRelationsValue" />
-							</g:FlowPanel>
-
-							<g:FlowPanel ui:field="objectPanel">
-							</g:FlowPanel>
-						</g:FlowPanel>
-					</g:FlowPanel>
-				</g:FlowPanel>
-			</g:FlowPanel>
-
-			<g:FlowPanel addStyleNames="col_2 last sidebar" ui:field="sidebarFlowPanel">
-				<g:FlowPanel addStyleNames="sticky-flow">
-					<g:FlowPanel addStyleNames="sticky-padding">
-						<g:SimplePanel addStyleNames="sidebar-group" ui:field="actionsSidebar" />
-					</g:FlowPanel>
-				</g:FlowPanel>
-			</g:FlowPanel>
-		</g:FlowPanel>
-	</g:FlowPanel>
+    <g:FocusPanel ui:field="keyboardFocus">
+        <g:FlowPanel styleName="browse" addStyleNames="wrapper skip_padding">
+            <common:NavigationToolbar ui:field="navigationToolbar"/>
+            <common:BrowseRepresentationInformationActionsToolbar ui:field="actionsToolbar"
+                                                                  label="{messages.representationInformationTitle}"/>
+            <g:FlowPanel addStyleNames="row full_width skip_padding">
+                <g:FlowPanel addStyleNames="col_12 content">
+                    <common:TitlePanel ui:field="title" icon="fa fa-info-circle"/>
+                    <tabs:BrowseRepresentationInformationTabs ui:field="browseRepresentationInformationTabs"/>
+                </g:FlowPanel>
+            </g:FlowPanel>
+        </g:FlowPanel>
+    </g:FocusPanel>
 </ui:UiBinder>

--- a/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/i18n/client/ClientMessages.properties
@@ -874,6 +874,10 @@ representationInformationRepresentations[\=1]:There is <a href="{1}">one represe
 representationInformationFiles:There are <a href="{1}">{0,number} files</a> associated with this representation information
 representationInformationFiles[\=0]:There are no files associated with this representation information
 representationInformationFiles[\=1]:There is <a href="{1}">one file</a> associated with this representation information
+representationInformationIntellectualEntitiesAssociations=Intellectual entities associations
+representationInformationRepresentationsAssociations=Representation associations
+representationInformationFilesAssociations=File associations
+
 # Descriptive Metadata
 
 metadataType:Type
@@ -1810,7 +1814,9 @@ detailsIdentifier: Identifier
 detailsLevel: Level
 detailsType: Type
 detailsState: State
-detailsCreatedOn: Created
+detailsCreatedOn: Created on
+detailsUpdatedOn: Updated on
+detailsUpdatedBy: Updated by
 detailsCreatedBy: Creator
 detailsModifiedOn: Modified
 detailsModifiedBy: Modifier


### PR DESCRIPTION
- refactored `ShowRepresentationInformation` in order to use breadcrumb, toolbar, and different tabs
- moved RepresentationInformation (RI) detail rendering to `DetailsPanelRepresentationInformation`
- introduced dedicated RI browse tabs for details + per-entity related associations
- RI actions toolbar with grouped actions and direct Start process button
- created i18n keys for details metadata labels and association tab titles
- updated breadcrumb CSS to keep root/last fully visible

resolves #3626 