### PR TITLE
feat: make list page size configurable via roda-wui.properties

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/common/RodaConstants.java
@@ -170,6 +170,9 @@ public final class RodaConstants {
   public static final String UI_LISTS_COLUMNS_DEFAULTSORTLIST_COLUMNNAME = "defaultSortList.columnName";
   public static final String UI_LISTS_COLUMNS_DEFAULTSORTLIST_ASCENDING = "defaultSortList.ascending";
 
+  public static final String UI_LISTS_PAGE_SIZE_INITIAL = "pageSize.initial";
+  public static final String UI_LISTS_PAGE_SIZE_INCREMENT = "pageSize.increment";
+
   public static final String UI_ICONS_CLASS = "ui.icons.class";
   public static final String UI_SERVICE_DROPFOLDER_URL = "ui.service.dropfolder.url";
   public static final String UI_SERVICE_CAS_URL = "ui.service.cas.url";

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCellOptions.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/lists/utils/AsyncTableCellOptions.java
@@ -73,8 +73,10 @@ public class AsyncTableCellOptions<T extends IsIndexed> {
     facets = FacetFactory.getFacets(listId);
     summary = AsyncTableCell.messages.searchResults();
     fieldsToReturn = Collections.emptyList();
-    initialPageSize = AsyncTableCell.DEFAULT_INITIAL_PAGE_SIZE;
-    pageSizeIncrement = AsyncTableCell.DEFAULT_PAGE_SIZE_INCREMENT;
+    initialPageSize = ConfigurationManager.getInt(AsyncTableCell.DEFAULT_INITIAL_PAGE_SIZE,
+      RodaConstants.UI_LISTS_PROPERTY, listId, RodaConstants.UI_LISTS_PAGE_SIZE_INITIAL);
+    pageSizeIncrement = ConfigurationManager.getInt(AsyncTableCell.DEFAULT_PAGE_SIZE_INCREMENT,
+      RodaConstants.UI_LISTS_PROPERTY, listId, RodaConstants.UI_LISTS_PAGE_SIZE_INCREMENT);
     checkboxSelectionListeners = new ArrayList<>();
     indexResultValueChangeHandlers = new ArrayList<>();
     extraStyleNames = new ArrayList<>();

--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -855,6 +855,20 @@ ui.icons.class.DisposalRule=fas fa-gavel
 ##########################################################################
 # List configuration
 #
+# ui.lists.{listName}.pageSize.initial
+#    Integer, defining the number of items shown initially in the list.
+#    Default: 20
+#
+# ui.lists.{listName}.pageSize.increment
+#    Integer, defining the number of items added when clicking "Show more".
+#    Default: 100
+#
+# Example: show 100 items by default in the Transfer and Assessment lists
+# ui.lists.IngestTransfer_transferredResources.pageSize.initial = 100
+# ui.lists.IngestAppraisal_searchAIPs.pageSize.initial = 100
+# ui.lists.IngestAppraisal_searchFiles.pageSize.initial = 100
+# ui.lists.IngestAppraisal_searchRepresentations.pageSize.initial = 100
+#
 # ui.lists.{listName}.search.enabled
 #    Boolean, defining if the search bar should be visible.
 #    Default: true


### PR DESCRIPTION
## Summary

- Added `UI_LISTS_PAGE_SIZE_INITIAL` and `UI_LISTS_PAGE_SIZE_INCREMENT` constants to `RodaConstants`
- `AsyncTableCellOptions` now reads initial page size and increment from the client configuration (falling back to the existing defaults of 20 and 100)
- Documented the new properties in `roda-wui.properties` with examples for the Transfer and Assessment lists

## Configuration

Any list's page size can now be controlled per list ID in `roda-wui.properties` (or a local overlay):

\`\`\`properties
# Transfer
ui.lists.IngestTransfer_transferredResources.pageSize.initial = 100

# Assessment (Appraisal)
ui.lists.IngestAppraisal_searchAIPs.pageSize.initial = 100
ui.lists.IngestAppraisal_searchFiles.pageSize.initial = 100
ui.lists.IngestAppraisal_searchRepresentations.pageSize.initial = 100
\`\`\`

No GWT recompile is needed — restarting the Spring Boot app picks up the new values.

## Test plan

- [ ] Add `ui.lists.Search_AIPs.pageSize.initial = 100` to `roda-wui.properties`
- [ ] Start the application and open the Catalogue/Search page
- [ ] Verify 100 AIPs are shown on first load instead of 20
- [ ] Remove the property and confirm it reverts to 20
- [ ] Confirm "Show more" still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)