### PR TITLE
fix(e2e): fix GET request NPE and deserialization errors in roda-api-tests

### DIFF
--- a/roda-api-tests/pom.xml
+++ b/roda-api-tests/pom.xml
@@ -32,9 +32,36 @@
 
   <properties>
     <testcontainers.version>2.0.2</testcontainers.version>
-    <restassured.version>5.5.2</restassured.version>
+    <restassured.version>5.5.7</restassured.version>
     <openapi.generator.version>7.10.0</openapi.generator.version>
   </properties>
+
+  <!--
+    Override the Groovy version inherited from Spring Boot 4.x BOM (which pins 5.0.5).
+    REST Assured 5.5.x was reverted to Groovy 4.0.22 starting from 5.5.3.
+    Groovy 5.0.x has a bug in ClosureMetaClass.invokeOnDelegationObject (GROOVY-11128
+    follow-up): getEnclosingClass() returns null for compiled REST Assured closures,
+    causing Class.isAssignableFrom(null) -> NullPointerException on any GET request.
+  -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.groovy</groupId>
+        <artifactId>groovy</artifactId>
+        <version>4.0.22</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.groovy</groupId>
+        <artifactId>groovy-xml</artifactId>
+        <version>4.0.22</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.groovy</groupId>
+        <artifactId>groovy-json</artifactId>
+        <version>4.0.22</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
 
@@ -165,8 +192,12 @@
           <suiteXmlFiles>
             <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
           </suiteXmlFiles>
-          <!-- 10 min actuator/health wait + test execution -->
-          <forkedProcessTimeoutInSeconds>720</forkedProcessTimeoutInSeconds>
+          <!-- 10 min actuator/health wait + 3 min LDAP poll + test execution -->
+          <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+          <!-- groovy.use.classvalue=true: use ClassValue (thread-safe) instead of
+               WeakHashMap for Groovy's metaclass cache. Improves thread safety
+               when REST Assured closures are invoked from TestNG worker threads. -->
+          <argLine>-Dgroovy.use.classvalue=true</argLine>
         </configuration>
       </plugin>
 

--- a/roda-api-tests/src/test/java/org/roda/tests/api/AbstractApiTest.java
+++ b/roda-api-tests/src/test/java/org/roda/tests/api/AbstractApiTest.java
@@ -13,7 +13,11 @@ import static io.restassured.RestAssured.preemptive;
 import java.io.File;
 import java.time.Duration;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.config.ObjectMapperConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ComposeContainer;
@@ -101,6 +105,16 @@ public abstract class AbstractApiTest {
     RestAssured.basePath = "/api/v2";
     RestAssured.defaultParser = io.restassured.parsing.Parser.JSON;
 
+    // Configure Jackson to ignore unknown fields — the server may return extra
+    // properties (e.g. "UUID" alongside "uuid") not present in the generated model.
+    RestAssured.config = RestAssured.config().objectMapperConfig(
+      ObjectMapperConfig.objectMapperConfig().jackson2ObjectMapperFactory(
+        (cls, charset) -> new ObjectMapper()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .registerModule(new JavaTimeModule())
+      )
+    );
+
     // requestSpecification is the most reliable way to set default auth globally
     // across all given() calls in REST Assured 5.x.
     RestAssured.requestSpecification = new RequestSpecBuilder()
@@ -118,7 +132,7 @@ public abstract class AbstractApiTest {
   }
 
   private void pollUntil(String label, java.util.function.BooleanSupplier condition) {
-    long deadline = System.currentTimeMillis() + Duration.ofMinutes(5).toMillis();
+    long deadline = System.currentTimeMillis() + Duration.ofMinutes(3).toMillis();
     int attempt = 0;
     while (System.currentTimeMillis() < deadline) {
       attempt++;


### PR DESCRIPTION
## Summary

- **Fix 1 — Groovy NPE on GET requests**: REST Assured 5.5.x GET requests failed with `NullPointerException` in Groovy 5.0.5's `ClosureMetaClass.invokeOnDelegationObject`. Spring Boot 4.0.6's BOM forces Groovy 5.0.5, which has a bug where `getEnclosingClass()` returns null for compiled REST Assured closures inside `sendHttpRequest`, breaking the `DELEGATE_FIRST` method dispatch. Fixed by upgrading REST Assured `5.5.2 → 5.5.7` (which reverted to Groovy 4.0.22 as its default) and pinning all three Groovy artifacts to `4.0.22` in `dependencyManagement` so the Spring Boot BOM cannot override them.
- **Fix 2 — Jackson deserialization of unknown fields**: The server returns a `UUID` field (uppercase) alongside `uuid` (lowercase) that is absent from the generated OpenAPI model POJOs. Configured REST Assured's Jackson `ObjectMapper` globally with `FAIL_ON_UNKNOWN_PROPERTIES=false` so extra server fields do not break `.as(SomeModel.class)` deserialization.
- **Fix 3 — LDAP poll timeout**: Corrected the `pollUntil` deadline from 5 minutes to 3 minutes (consistent with the comment) and bumped the Surefire forked process timeout from 720 s to 1200 s to cover the 10-min health check + 3-min LDAP poll window.

## Test plan

- [x] All 4 E2E tests pass: `Tests run: 4, Failures: 0, Errors: 0, Skipped: 0` (~3 min runtime)
  - `getAuthenticatedUser_returnsAdminUser`
  - `countAips_withAllFilter_returns200AndNonNegativeCount`
  - `findAips_withAllFilter_returns200AndValidIndexResult`
  - `getAipConfigurationTypes_returns200`
- [x] `mvn dependency:list -f roda-api-tests/pom.xml | grep groovy` confirms `4.0.22` is resolved (not `5.0.5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)