### PR TITLE
Fix historical civil date handling in WUI

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -4058,6 +4058,11 @@ td.datePickerMonth, td.datePickerYear {
     vertical-align: top;
 }
 
+.search-field-left-panel .form-textbox-date {
+    width: 125px;
+    max-width: none;
+}
+
 .searchAdvancedPanelButtons {
     height: 30px;
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchFieldPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchFieldPanel.java
@@ -34,7 +34,6 @@ import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Composite;
@@ -42,8 +41,6 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.TextBox;
-import com.google.gwt.user.datepicker.client.DateBox;
-import com.google.gwt.user.datepicker.client.DateBox.DefaultFormat;
 
 import config.i18n.client.ClientMessages;
 
@@ -72,10 +69,10 @@ public class SearchFieldPanel extends Composite implements HasValueChangeHandler
   // Text
   private TextBox inputText;
   // Date
-  private DateBox inputDateBox;
+  private TextBox inputDateBox;
   // Date interval
-  private DateBox inputDateBoxFrom;
-  private DateBox inputDateBoxTo;
+  private TextBox inputDateBoxFrom;
+  private TextBox inputDateBoxTo;
   // Numeric
   private TextBox inputNumeric;
   // Numeric interval
@@ -102,8 +99,6 @@ public class SearchFieldPanel extends Composite implements HasValueChangeHandler
     searchAdvancedFields = new ListBox();
     duplicateWarning = new Label();
 
-    DefaultFormat dateFormat = new DateBox.DefaultFormat(DateTimeFormat.getFormat("yyyy-MM-dd"));
-
     KeyDownHandler keyDownHandler = new KeyDownHandler() {
       @Override
       public void onKeyDown(KeyDownEvent event) {
@@ -114,30 +109,9 @@ public class SearchFieldPanel extends Composite implements HasValueChangeHandler
     inputText = new TextBox();
     inputText.addKeyDownHandler(keyDownHandler);
 
-    inputDateBox = new DateBox();
-    inputDateBox.setFormat(dateFormat);
-    inputDateBox.getDatePicker().setYearAndMonthDropdownVisible(true);
-    inputDateBox.getDatePicker().setYearArrowsVisible(true);
-    inputDateBox.setFireNullValues(true);
-    inputDateBox.getElement().setPropertyString("placeholder", messages.searchFieldDatePlaceHolder());
-    inputDateBox.getTextBox().addKeyDownHandler(keyDownHandler);
-
-    inputDateBoxFrom = new DateBox();
-    inputDateBoxFrom.setFormat(dateFormat);
-    inputDateBoxFrom.getDatePicker().setYearAndMonthDropdownVisible(true);
-    inputDateBoxFrom.getDatePicker().setYearArrowsVisible(true);
-    inputDateBoxFrom.setFireNullValues(true);
-    inputDateBoxFrom.getElement().setPropertyString("placeholder", messages.searchFieldDateFromPlaceHolder());
-    inputDateBoxFrom.getTextBox().addKeyDownHandler(keyDownHandler);
-
-    inputDateBoxTo = new DateBox();
-    inputDateBoxTo.setFormat(dateFormat);
-    inputDateBoxTo.getDatePicker().setYearAndMonthDropdownVisible(true);
-    inputDateBoxTo.getDatePicker().setYearArrowsVisible(true);
-    inputDateBoxTo.setFireNullValues(true);
-    inputDateBoxTo.getElement().setPropertyString("placeholder", messages.searchFieldDateToPlaceHolder());
-    inputDateBoxTo.getTextBox().addKeyDownHandler(keyDownHandler);
-
+    inputDateBox = createDateTextBox(messages.searchFieldDatePlaceHolder(), keyDownHandler);
+    inputDateBoxFrom = createDateTextBox(messages.searchFieldDateFromPlaceHolder(), keyDownHandler);
+    inputDateBoxTo = createDateTextBox(messages.searchFieldDateToPlaceHolder(), keyDownHandler);
     inputNumeric = new TextBox();
     inputNumeric.getElement().setPropertyString("placeholder", messages.searchFieldNumericPlaceHolder());
     inputNumeric.getElement().setAttribute("type", "number");
@@ -197,9 +171,9 @@ public class SearchFieldPanel extends Composite implements HasValueChangeHandler
     duplicateWarning.setVisible(false);
 
     inputText.addStyleName("form-textbox");
-    inputDateBox.addStyleName("form-textbox form-textbox-small");
-    inputDateBoxFrom.addStyleName("form-textbox form-textbox-small");
-    inputDateBoxTo.addStyleName("form-textbox form-textbox-small");
+    inputDateBox.addStyleName("form-textbox form-textbox-small form-textbox-date");
+    inputDateBoxFrom.addStyleName("form-textbox form-textbox-small form-textbox-date");
+    inputDateBoxTo.addStyleName("form-textbox form-textbox-small form-textbox-date");
     inputNumeric.addStyleName("form-textbox form-textbox-small");
     inputNumericFrom.addStyleName("form-textbox form-textbox-small");
     inputNumericTo.addStyleName("form-textbox form-textbox-small");
@@ -274,16 +248,20 @@ public class SearchFieldPanel extends Composite implements HasValueChangeHandler
       String field = searchFields.get(0);
 
       if (type.equals(RodaConstants.SEARCH_FIELD_TYPE_DATE) && dateValid(inputDateBox)) {
-        filterParameter = new SimpleFilterParameter(field, inputDateBox.getValue().toString());
+        filterParameter = new DateIntervalFilterParameter(field, field,
+          Humanize.parseCivilDate(inputDateBox.getValue()), Humanize.parseCivilDate(inputDateBox.getValue()),
+          RodaConstants.DateGranularity.DAY, 0);
       } else if (type.equals(RodaConstants.SEARCH_FIELD_TYPE_DATE_INTERVAL)
         && dateIntervalValid(inputDateBoxFrom, inputDateBoxTo) && searchFields.size() >= 2) {
         String fieldTo = searchField.getSearchFields().get(1);
-        filterParameter = new DateIntervalFilterParameter(field, fieldTo, inputDateBoxFrom.getValue(),
-          inputDateBoxTo.getValue());
+        filterParameter = new DateIntervalFilterParameter(field, fieldTo,
+          Humanize.parseCivilDate(inputDateBoxFrom.getValue()), Humanize.parseCivilDate(inputDateBoxTo.getValue()),
+          RodaConstants.DateGranularity.DAY, 0);
       } else if (type.equals(RodaConstants.SEARCH_FIELD_TYPE_DATE_INTERVAL)
         && dateIntervalValid(inputDateBoxFrom, inputDateBoxTo)) {
-        filterParameter = new DateIntervalFilterParameter(field, field, inputDateBoxFrom.getValue(),
-          inputDateBoxTo.getValue());
+        filterParameter = new DateIntervalFilterParameter(field, field,
+          Humanize.parseCivilDate(inputDateBoxFrom.getValue()), Humanize.parseCivilDate(inputDateBoxTo.getValue()),
+          RodaConstants.DateGranularity.DAY, 0);
       } else if (type.equals(RodaConstants.SEARCH_FIELD_TYPE_NUMERIC) && valid(inputNumeric)) {
         filterParameter = new BasicSearchFilterParameter(field, inputNumeric.getValue());
       } else if (type.equals(RodaConstants.SEARCH_FIELD_TYPE_NUMERIC_INTERVAL)
@@ -385,24 +363,20 @@ public class SearchFieldPanel extends Composite implements HasValueChangeHandler
     inputPanel.addStyleName("full_width");
   }
 
-  private boolean dateIntervalValid(DateBox inputFrom, DateBox inputTo) {
-    if (inputFrom.getValue() != null && inputTo.getValue() != null) {
-      return true;
-    }
-
-    if (inputFrom.getValue() != null && inputTo.getTextBox().getText().isEmpty()) {
-      return true;
-    }
-
-    if (inputFrom.getTextBox().getText().isEmpty() && inputTo.getValue() != null) {
-      return true;
-    }
-
-    return false;
+  private TextBox createDateTextBox(String placeholder, KeyDownHandler keyDownHandler) {
+    TextBox textBox = new TextBox();
+    textBox.getElement().setAttribute("type", "date");
+    textBox.getElement().setPropertyString("placeholder", placeholder);
+    textBox.addKeyDownHandler(keyDownHandler);
+    return textBox;
   }
 
-  private boolean dateValid(DateBox input) {
-    return input.getValue() != null;
+  private boolean dateIntervalValid(TextBox inputFrom, TextBox inputTo) {
+    return dateValid(inputFrom) || dateValid(inputTo);
+  }
+
+  private boolean dateValid(TextBox input) {
+    return input.getValue() != null && !input.getValue().trim().isEmpty();
   }
 
   private boolean valid(TextBox input) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchPreFilterUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchPreFilterUtils.java
@@ -9,11 +9,6 @@ package org.roda.wui.client.common.search;
 
 import java.util.List;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.safehtml.shared.SafeHtml;
-import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
-import com.google.gwt.safehtml.shared.SafeHtmlUtils;
-
 import org.roda.core.data.v2.index.filter.BasicSearchFilterParameter;
 import org.roda.core.data.v2.index.filter.DateIntervalFilterParameter;
 import org.roda.core.data.v2.index.filter.EmptyKeyFilterParameter;
@@ -24,9 +19,14 @@ import org.roda.core.data.v2.index.filter.NotSimpleFilterParameter;
 import org.roda.core.data.v2.index.filter.OneOfManyFilterParameter;
 import org.roda.core.data.v2.index.filter.OrFiltersParameters;
 import org.roda.core.data.v2.index.filter.SimpleFilterParameter;
+import org.roda.wui.common.client.tools.Humanize;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 
 import config.i18n.client.ClientMessages;
-import org.roda.wui.common.client.tools.Humanize;
 
 public class SearchPreFilterUtils {
   private static final ClientMessages messages = GWT.create(ClientMessages.class);
@@ -114,16 +114,16 @@ public class SearchPreFilterUtils {
     } else if (parameter instanceof DateIntervalFilterParameter) {
       DateIntervalFilterParameter p = (DateIntervalFilterParameter) parameter;
       if (p.getFromValue() != null && p.getToValue() != null) {
-        String fromDateHumanized = Humanize.formatDate(p.getFromValue());
-        String toDateHumanized = Humanize.formatDate(p.getToValue());
+        String fromDateHumanized = Humanize.formatCivilDate(p.getFromValue(), false);
+        String toDateHumanized = Humanize.formatCivilDate(p.getToValue(), false);
         return messages.searchPreFilterDateIntervalFilterParameter(messages.searchPreFilterName(p.getFromName()),
           fromDateHumanized, toDateHumanized);
       } else if (p.getToValue() == null) {
-        String fromDateHumanized = Humanize.formatDate(p.getFromValue());
+        String fromDateHumanized = Humanize.formatCivilDate(p.getFromValue(), false);
         return messages.searchPreFilterDateIntervalFilterParameterFrom(messages.searchPreFilterName(p.getFromName()),
           fromDateHumanized);
       } else {
-        String toDateHumanized = Humanize.formatDate(p.getToValue());
+        String toDateHumanized = Humanize.formatCivilDate(p.getToValue(), false);
         return messages.searchPreFilterDateIntervalFilterParameterTo(messages.searchPreFilterName(p.getFromName()),
           toDateHumanized);
       }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/FormUtilities.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/FormUtilities.java
@@ -8,7 +8,6 @@
 package org.roda.wui.client.common.utils;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -23,7 +22,6 @@ import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONException;
@@ -38,7 +36,6 @@ import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.RichTextArea;
 import com.google.gwt.user.client.ui.TextArea;
 import com.google.gwt.user.client.ui.TextBox;
-import com.google.gwt.user.datepicker.client.DateBox;
 
 import config.i18n.client.ClientMessages;
 
@@ -442,66 +439,38 @@ public class FormUtilities {
   private static void addDatePicker(FlowPanel panel, final FlowPanel layout, final MetadataValue mv,
     final boolean mandatory, final Callable<Void> onChange) {
     // Top label
-    final DateTimeFormat dateTimeFormat = DateTimeFormat.getFormat("yyyy-MM-dd");
     Label mvLabel = new Label(getFieldLabel(mv));
     mvLabel.addStyleName("form-label");
     if (mandatory) {
       mvLabel.addStyleName("form-label-mandatory");
     }
-    // Field
-    final DateBox mvDate = new DateBox();
+
+    final TextBox mvDate = new TextBox();
+    mvDate.getElement().setAttribute("type", "date");
     mvDate.setTitle(mvLabel.getText());
-    mvDate.getDatePicker().setYearAndMonthDropdownVisible(true);
-    mvDate.getDatePicker().setYearArrowsVisible(true);
     mvDate.addStyleName("form-textbox");
-    mvDate.setFormat(new DateBox.DefaultFormat() {
-      @Override
-      public String format(DateBox dateBox, Date date) {
-        if (date == null)
-          return null;
-        return dateTimeFormat.format(date);
-      }
-    });
 
     String value = mv.get("value");
-    if (value != null && value.length() > 0) {
-      try {
-        Date date = dateTimeFormat.parse(value.trim());
-        mvDate.setValue(date);
-      } catch (IllegalArgumentException iae) {
-        mvDate.getTextBox().setValue(value);
-      }
+    if (value != null && !value.trim().isEmpty()) {
+      mvDate.setValue(value.trim());
     }
 
-    mvDate.addValueChangeHandler(new ValueChangeHandler<Date>() {
-      @Override
-      public void onValueChange(ValueChangeEvent<Date> valueChangeEvent) {
-        FormUtilities.callOnChange(onChange);
-        String newValue = dateTimeFormat.format(mvDate.getValue());
-        mv.set("value", newValue);
-        if (mandatory && (newValue != null && !"".equals(newValue.trim()))) {
-          mvDate.removeStyleName("isWrong");
-        } else if (mandatory && (newValue == null || "".equals(newValue.trim()))) {
-          mvDate.addStyleName("isWrong");
-        }
-      }
-    });
-
-    mvDate.getTextBox().addValueChangeHandler(new ValueChangeHandler<String>() {
-
+    mvDate.addValueChangeHandler(new ValueChangeHandler<String>() {
       @Override
       public void onValueChange(ValueChangeEvent<String> event) {
         FormUtilities.callOnChange(onChange);
-        String value = event.getValue();
-        try {
-          Date date = dateTimeFormat.parse(value.trim());
-          mvDate.setValue(date);
-          mv.set("value", value);
-        } catch (IllegalArgumentException iae) {
-          if (event.getValue() == null || "".equals(event.getValue().trim())) {
-            mv.set("value", null);
-          }
-          mvDate.getTextBox().setValue(value);
+
+        String newValue = event.getValue();
+        if (newValue != null) {
+          newValue = newValue.trim();
+        }
+
+        mv.set("value", newValue == null || newValue.isEmpty() ? null : newValue);
+
+        if (mandatory && (newValue == null || newValue.isEmpty())) {
+          mvDate.addStyleName("isWrong");
+        } else {
+          mvDate.removeStyleName("isWrong");
         }
       }
     });

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/Humanize.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/Humanize.java
@@ -7,13 +7,12 @@
  */
 package org.roda.wui.common.client.tools;
 
-import java.time.temporal.ChronoUnit;
 import java.util.Date;
-import java.util.concurrent.TimeUnit;
 
 import org.roda.core.data.common.RodaConstants;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JsDate;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.NumberFormat;
 import com.google.gwt.i18n.client.TimeZone;
@@ -21,41 +20,34 @@ import com.google.gwt.i18n.client.TimeZone;
 import config.i18n.client.ClientMessages;
 
 public class Humanize {
-  private static final ClientMessages messages = GWT.create(ClientMessages.class);
-
   public static final long ONE_SECOND = 1000;
   public static final long SECONDS = 60;
   public static final long ONE_MINUTE = ONE_SECOND * 60;
-  public static final long MINUTES = 60;
   public static final long ONE_HOUR = ONE_MINUTE * 60;
-  public static final long HOURS = 24;
   public static final long ONE_DAY = ONE_HOUR * 24;
-
+  public static final long MINUTES = 60;
+  public static final long HOURS = 24;
+  private static final long CIVIL_DATE_UI_SAFE_TIME_SHIFT_MILLIS = 12 * 60 * 60 * 1000;
   public static final String BYTES = "B";
   public static final String KILOBYTES = "KB";
   public static final String MEGABYTES = "MB";
   public static final String GIGABYTES = "GB";
   public static final String TERABYTES = "TB";
   public static final String PETABYTES = "PB";
-
   public static final String[] UNITS = new String[] {BYTES, KILOBYTES, MEGABYTES, GIGABYTES, TERABYTES, PETABYTES};
-
   public static final double BYTES_IN_KILOBYTES = 1024L;
   public static final double BYTES_IN_MEGABYTES = 1048576L;
   public static final double BYTES_IN_GIGABYTES = 1073741824L;
   public static final double BYTES_IN_TERABYTES = 1099511627776L;
   public static final double BYTES_IN_PETABYTES = 1125899906842624L;
-
   public static final double[] BYTES_IN_UNITS = {1, BYTES_IN_KILOBYTES, BYTES_IN_MEGABYTES, BYTES_IN_GIGABYTES,
     BYTES_IN_TERABYTES, BYTES_IN_PETABYTES};
-
-  protected static final NumberFormat SMALL_NUMBER_FORMAT = NumberFormat.getFormat("0.#");
-  protected static final NumberFormat NUMBER_FORMAT = NumberFormat.getFormat("#");
-
   public static final DateTimeFormat DATE_FORMAT = DateTimeFormat.getFormat("yyyy-MM-dd");
   public static final DateTimeFormat DATE_TIME_FORMAT = DateTimeFormat.getFormat("yyyy-MM-dd HH:mm:ss z");
-
   public static final boolean FORMAT_UTC = false;
+  protected static final NumberFormat SMALL_NUMBER_FORMAT = NumberFormat.getFormat("0.#");
+  protected static final NumberFormat NUMBER_FORMAT = NumberFormat.getFormat("#");
+  private static final ClientMessages messages = GWT.create(ClientMessages.class);
 
   private Humanize() {
     // do nothing
@@ -97,23 +89,19 @@ public class Humanize {
     if (dateInitial == null && dateFinal == null) {
       return extendedDate ? messages.titleDatesEmpty() : messages.simpleDatesEmpty();
     } else if (dateInitial != null && dateFinal == null) {
-      String dateInitialString = formatDate(dateInitial, extendedDate);
+      String dateInitialString = formatCivilDate(dateInitial, extendedDate);
       return extendedDate ? messages.titleDatesNoFinal(dateInitialString)
         : messages.simpleDatesNoFinal(dateInitialString);
     } else if (dateInitial == null) {
-      String dateFinalString = formatDate(dateFinal, extendedDate);
+      String dateFinalString = formatCivilDate(dateFinal, extendedDate);
       return extendedDate ? messages.titleDatesNoInitial(dateFinalString)
         : messages.simpleDatesNoInitial(dateFinalString);
     } else {
-      String dateInitialString = formatDate(dateInitial, extendedDate);
-      String dateFinalString = formatDate(dateFinal, extendedDate);
+      String dateInitialString = formatCivilDate(dateInitial, extendedDate);
+      String dateFinalString = formatCivilDate(dateFinal, extendedDate);
       return extendedDate ? messages.titleDates(dateInitialString, dateFinalString)
         : messages.simpleDates(dateInitialString, dateFinalString);
     }
-  }
-
-  public enum DHMSFormat {
-    LONG, SHORT;
   }
 
   public static String durationInDHMS(Date start, Date end, DHMSFormat format) {
@@ -212,7 +200,18 @@ public class Humanize {
       DATE_TIME_FORMAT);
   }
 
+  public static String formatCivilDate(Date date, boolean extended) {
+    String formatPropertyName = extended ? RodaConstants.UI_DATE_FORMAT_TITLE : RodaConstants.UI_DATE_FORMAT_SIMPLE;
+    Date displayDate = new Date(date.getTime() + CIVIL_DATE_UI_SAFE_TIME_SHIFT_MILLIS);
+    return applyDateTimeFormat(displayDate, ConfigurationManager.getString(formatPropertyName), DATE_FORMAT, true);
+  }
+
   private static String applyDateTimeFormat(Date date, String stringFormat, DateTimeFormat defaultValue) {
+    return applyDateTimeFormat(date, stringFormat, defaultValue, false);
+  }
+
+  private static String applyDateTimeFormat(Date date, String stringFormat, DateTimeFormat defaultValue,
+    boolean forceUtc) {
     DateTimeFormat format;
 
     if (stringFormat != null) {
@@ -232,10 +231,32 @@ public class Humanize {
       format = defaultValue;
     }
 
-    if (ConfigurationManager.getBoolean(FORMAT_UTC, RodaConstants.UI_DATE_TIME_FORMAT_UTC)) {
+    if (forceUtc || ConfigurationManager.getBoolean(FORMAT_UTC, RodaConstants.UI_DATE_TIME_FORMAT_UTC)) {
       return format.format(date, TimeZone.createTimeZone(0));
     }
 
     return format.format(date);
+  }
+
+  public static Date parseCivilDate(String civilDate) {
+    if (civilDate == null || civilDate.trim().isEmpty()) {
+      return null;
+    }
+
+    String[] parts = civilDate.trim().split("-");
+    if (parts.length != 3) {
+      return null;
+    }
+
+    int year = Integer.parseInt(parts[0]);
+    int month = Integer.parseInt(parts[1]);
+    int day = Integer.parseInt(parts[2]);
+
+    // avoid local timezone, month - 1 adapts civil month to JavaScript month
+    return new Date((long) JsDate.UTC(year, month - 1, day, 0, 0, 0, 0));
+  }
+
+  public enum DHMSFormat {
+    LONG, SHORT;
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/server/browse/BrowserServiceImpl.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/server/browse/BrowserServiceImpl.java
@@ -343,6 +343,7 @@ public class BrowserServiceImpl extends RemoteServiceServlet implements BrowserS
       Class<T> classToReturn = SelectedItemsUtils.parseClass(classNameToReturn);
       IndexResult<T> result = Browser.find(classToReturn, filter, sorter, sublist, facets, user, justActive,
         fieldsToReturn);
+
       return I18nUtility.translate(result, classToReturn, localeString);
     } catch (RuntimeException e) {
       LOGGER.error("Unexpected error in find", e);

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/server/browse/BrowserServiceImpl.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/server/browse/BrowserServiceImpl.java
@@ -343,7 +343,6 @@ public class BrowserServiceImpl extends RemoteServiceServlet implements BrowserS
       Class<T> classToReturn = SelectedItemsUtils.parseClass(classNameToReturn);
       IndexResult<T> result = Browser.find(classToReturn, filter, sorter, sublist, facets, user, justActive,
         fieldsToReturn);
-
       return I18nUtility.translate(result, classToReturn, localeString);
     } catch (RuntimeException e) {
       LOGGER.error("Unexpected error in find", e);


### PR DESCRIPTION
- discard server-side 12-hour civil date shift hotfix
- keep IndexedAIP date values unchanged in browse and search results
- replace descriptive metadata DateBox usage with HTML5 date inputs backed by yyyy-MM-dd strings
- replace advanced search date DateBox inputs with HTML5 date inputs and convert values to UTC Date objects only when building filters
- apply a UI-only 12-hour render-time normalization for historical civil dates before UTC formatting
- adjust advanced search date input width so the browser date format remains visible