### PR TITLE
Fix historical civil date handling in WUI in RODA 6

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/resources/main.gss
@@ -4959,6 +4959,11 @@ td.datePickerMonth, td.datePickerYear {
     vertical-align: top;
 }
 
+.search-field-left-panel .form-textbox-date {
+    width: 125px;
+    max-width: none;
+}
+
 .searchAdvancedPanelButtons {
     height: 30px;
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchFieldPanel.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchFieldPanel.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import com.google.gwt.user.client.ui.SimplePanel;
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.v2.index.filter.BasicSearchFilterParameter;
 import org.roda.core.data.v2.index.filter.DateIntervalFilterParameter;
@@ -34,16 +33,14 @@ import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.TextBox;
-import com.google.gwt.user.datepicker.client.DateBox;
-import com.google.gwt.user.datepicker.client.DateBox.DefaultFormat;
 
 import config.i18n.client.ClientMessages;
 
@@ -73,12 +70,12 @@ public class SearchFieldPanel extends Composite implements HasValueChangeHandler
   // Text
   private TextBox inputText;
   // Date
-  private DateBox inputDateBox;
+  private TextBox inputDateBox;
   // Date interval
   private Label inputDateBoxFromLabel;
-  private DateBox inputDateBoxFrom;
+  private TextBox inputDateBoxFrom;
   private Label inputDateBoxToLabel;
-  private DateBox inputDateBoxTo;
+  private TextBox inputDateBoxTo;
   // Numeric
   private TextBox inputNumeric;
   // Numeric interval
@@ -110,8 +107,6 @@ public class SearchFieldPanel extends Composite implements HasValueChangeHandler
     duplicateWarningPanel = new SimplePanel();
     duplicateWarningLabel = new Label();
 
-    DefaultFormat dateFormat = new DateBox.DefaultFormat(DateTimeFormat.getFormat("yyyy-MM-dd"));
-
     KeyDownHandler keyDownHandler = new KeyDownHandler() {
       @Override
       public void onKeyDown(KeyDownEvent event) {
@@ -122,31 +117,13 @@ public class SearchFieldPanel extends Composite implements HasValueChangeHandler
     inputText = new TextBox();
     inputText.addKeyDownHandler(keyDownHandler);
 
-    inputDateBox = new DateBox();
-    inputDateBox.setFormat(dateFormat);
-    inputDateBox.getDatePicker().setYearAndMonthDropdownVisible(true);
-    inputDateBox.getDatePicker().setYearArrowsVisible(true);
-    inputDateBox.setFireNullValues(true);
-    // inputDateBox.getElement().setPropertyString("placeholder", messages.searchFieldDatePlaceHolder());
-    inputDateBox.getTextBox().addKeyDownHandler(keyDownHandler);
+    inputDateBox = createDateTextBox(messages.searchFieldDatePlaceHolder(), keyDownHandler);
 
     inputDateBoxFromLabel = new Label(messages.genericRangeFieldFrom());
-    inputDateBoxFrom = new DateBox();
-    inputDateBoxFrom.setFormat(dateFormat);
-    inputDateBoxFrom.getDatePicker().setYearAndMonthDropdownVisible(true);
-    inputDateBoxFrom.getDatePicker().setYearArrowsVisible(true);
-    inputDateBoxFrom.setFireNullValues(true);
-    // inputDateBoxFrom.getElement().setPropertyString("placeholder", messages.searchFieldDateFromPlaceHolder());
-    inputDateBoxFrom.getTextBox().addKeyDownHandler(keyDownHandler);
+    inputDateBoxFrom = createDateTextBox(messages.searchFieldDateFromPlaceHolder(), keyDownHandler);
 
     inputDateBoxToLabel = new Label(messages.genericRangeFieldTo());
-    inputDateBoxTo = new DateBox();
-    inputDateBoxTo.setFormat(dateFormat);
-    inputDateBoxTo.getDatePicker().setYearAndMonthDropdownVisible(true);
-    inputDateBoxTo.getDatePicker().setYearArrowsVisible(true);
-    inputDateBoxTo.setFireNullValues(true);
-    // inputDateBoxTo.getElement().setPropertyString("placeholder", messages.searchFieldDateToPlaceHolder());
-    inputDateBoxTo.getTextBox().addKeyDownHandler(keyDownHandler);
+    inputDateBoxTo = createDateTextBox(messages.searchFieldDateToPlaceHolder(), keyDownHandler);
 
     inputNumeric = new TextBox();
     // inputNumeric.getElement().setPropertyString("placeholder", messages.searchFieldNumericPlaceHolder());
@@ -212,9 +189,9 @@ public class SearchFieldPanel extends Composite implements HasValueChangeHandler
     duplicateWarningPanel.setVisible(false);
 
     inputText.addStyleName("form-textbox");
-    inputDateBox.addStyleName("form-textbox form-textbox-small");
-    inputDateBoxFrom.addStyleName("form-textbox");
-    inputDateBoxTo.addStyleName("form-textbox");
+    inputDateBox.addStyleName("form-textbox form-textbox-small form-textbox-date");
+    inputDateBoxFrom.addStyleName("form-textbox form-textbox-date");
+    inputDateBoxTo.addStyleName("form-textbox form-textbox-date");
     inputNumeric.addStyleName("form-textbox form-textbox-small");
     inputNumericFrom.addStyleName("form-textbox");
     inputNumericTo.addStyleName("form-textbox");
@@ -289,16 +266,19 @@ public class SearchFieldPanel extends Composite implements HasValueChangeHandler
       String field = searchFields.get(0);
 
       if (type.equals(RodaConstants.SEARCH_FIELD_TYPE_DATE) && dateValid(inputDateBox)) {
-        filterParameter = new SimpleFilterParameter(field, inputDateBox.getValue().toString());
+        filterParameter = new DateIntervalFilterParameter(field, field, Humanize.parseCivilDate(inputDateBox.getValue()),
+          Humanize.parseCivilDate(inputDateBox.getValue()), RodaConstants.DateGranularity.DAY, 0);
       } else if (type.equals(RodaConstants.SEARCH_FIELD_TYPE_DATE_INTERVAL)
         && dateIntervalValid(inputDateBoxFrom, inputDateBoxTo) && searchFields.size() >= 2) {
         String fieldTo = searchField.getSearchFields().get(1);
-        filterParameter = new DateIntervalFilterParameter(field, fieldTo, inputDateBoxFrom.getValue(),
-          inputDateBoxTo.getValue());
+        filterParameter = new DateIntervalFilterParameter(field, fieldTo,
+          Humanize.parseCivilDate(inputDateBoxFrom.getValue()), Humanize.parseCivilDate(inputDateBoxTo.getValue()),
+          RodaConstants.DateGranularity.DAY, 0);
       } else if (type.equals(RodaConstants.SEARCH_FIELD_TYPE_DATE_INTERVAL)
         && dateIntervalValid(inputDateBoxFrom, inputDateBoxTo)) {
-        filterParameter = new DateIntervalFilterParameter(field, field, inputDateBoxFrom.getValue(),
-          inputDateBoxTo.getValue());
+        filterParameter = new DateIntervalFilterParameter(field, field,
+          Humanize.parseCivilDate(inputDateBoxFrom.getValue()), Humanize.parseCivilDate(inputDateBoxTo.getValue()),
+          RodaConstants.DateGranularity.DAY, 0);
       } else if (type.equals(RodaConstants.SEARCH_FIELD_TYPE_NUMERIC) && valid(inputNumeric)) {
         filterParameter = new BasicSearchFilterParameter(field, inputNumeric.getValue());
       } else if (type.equals(RodaConstants.SEARCH_FIELD_TYPE_NUMERIC_INTERVAL)
@@ -407,24 +387,20 @@ public class SearchFieldPanel extends Composite implements HasValueChangeHandler
     inputPanel.addStyleName("full_width");
   }
 
-  private boolean dateIntervalValid(DateBox inputFrom, DateBox inputTo) {
-    if (inputFrom.getValue() != null && inputTo.getValue() != null) {
-      return true;
-    }
-
-    if (inputFrom.getValue() != null && inputTo.getTextBox().getText().isEmpty()) {
-      return true;
-    }
-
-    if (inputFrom.getTextBox().getText().isEmpty() && inputTo.getValue() != null) {
-      return true;
-    }
-
-    return false;
+  private TextBox createDateTextBox(String placeholder, KeyDownHandler keyDownHandler) {
+    TextBox textBox = new TextBox();
+    textBox.getElement().setAttribute("type", "date");
+    textBox.getElement().setPropertyString("placeholder", placeholder);
+    textBox.addKeyDownHandler(keyDownHandler);
+    return textBox;
   }
 
-  private boolean dateValid(DateBox input) {
-    return input.getValue() != null;
+  private boolean dateIntervalValid(TextBox inputFrom, TextBox inputTo) {
+    return dateValid(inputFrom) || dateValid(inputTo);
+  }
+
+  private boolean dateValid(TextBox input) {
+    return input.getValue() != null && !input.getValue().trim().isEmpty();
   }
 
   private boolean valid(TextBox input) {

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchPreFilterUtils.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/search/SearchPreFilterUtils.java
@@ -115,16 +115,16 @@ public class SearchPreFilterUtils {
     } else if (parameter instanceof DateIntervalFilterParameter) {
       DateIntervalFilterParameter p = (DateIntervalFilterParameter) parameter;
       if (p.getFromValue() != null && p.getToValue() != null) {
-        String fromDateHumanized = Humanize.formatDate(p.getFromValue());
-        String toDateHumanized = Humanize.formatDate(p.getToValue());
+        String fromDateHumanized = Humanize.formatCivilDate(p.getFromValue(), false);
+        String toDateHumanized = Humanize.formatCivilDate(p.getToValue(), false);
         return messages.searchPreFilterDateIntervalFilterParameter(messages.searchPreFilterName(p.getFromName()),
           fromDateHumanized, toDateHumanized);
       } else if (p.getToValue() == null) {
-        String fromDateHumanized = Humanize.formatDate(p.getFromValue());
+        String fromDateHumanized = Humanize.formatCivilDate(p.getFromValue(), false);
         return messages.searchPreFilterDateIntervalFilterParameterFrom(messages.searchPreFilterName(p.getFromName()),
           fromDateHumanized);
       } else {
-        String toDateHumanized = Humanize.formatDate(p.getToValue());
+        String toDateHumanized = Humanize.formatCivilDate(p.getToValue(), false);
         return messages.searchPreFilterDateIntervalFilterParameterTo(messages.searchPreFilterName(p.getFromName()),
           toDateHumanized);
       }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/FormUtilities.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/client/common/utils/FormUtilities.java
@@ -8,7 +8,6 @@
 package org.roda.wui.client.common.utils;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -26,7 +25,6 @@ import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwt.json.client.JSONArray;
 import com.google.gwt.json.client.JSONException;
@@ -42,7 +40,6 @@ import com.google.gwt.user.client.ui.RichTextArea;
 import com.google.gwt.user.client.ui.TextArea;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.Widget;
-import com.google.gwt.user.datepicker.client.DateBox;
 
 import config.i18n.client.ClientMessages;
 import org.roda.wui.common.client.tools.StringUtils;
@@ -478,7 +475,6 @@ public class FormUtilities {
   private static void addDatePicker(FlowPanel panel, final FlowPanel layout, final MetadataValue mv,
                                     final boolean mandatory, final Callable<Void> onChange) {
     // Top label
-    final DateTimeFormat dateTimeFormat = DateTimeFormat.getFormat("yyyy-MM-dd");
     Label mvLabel = new Label(getFieldLabel(mv));
     mvLabel.addStyleName("form-label");
     if (mandatory) {
@@ -487,58 +483,31 @@ public class FormUtilities {
     }
 
     // Field
-    final DateBox mvDate = new DateBox();
+    final TextBox mvDate = new TextBox();
+    mvDate.getElement().setAttribute("type", "date");
     mvDate.setTitle(mvLabel.getText());
-    mvDate.getDatePicker().setYearAndMonthDropdownVisible(true);
-    mvDate.getDatePicker().setYearArrowsVisible(true);
     mvDate.addStyleName("form-textbox");
-    mvDate.setFormat(new DateBox.DefaultFormat() {
-      @Override
-      public String format(DateBox dateBox, Date date) {
-        if (date == null)
-          return null;
-        return dateTimeFormat.format(date);
-      }
-    });
 
     String value = mv.get("value");
-    if (value != null && value.length() > 0) {
-      try {
-        Date date = dateTimeFormat.parse(value.trim());
-        mvDate.setValue(date);
-      } catch (IllegalArgumentException iae) {
-        mvDate.getTextBox().setValue(value);
-      }
+    if (value != null && !value.trim().isEmpty()) {
+      mvDate.setValue(value.trim());
     }
 
-    mvDate.addValueChangeHandler(new ValueChangeHandler<Date>() {
-      @Override
-      public void onValueChange(ValueChangeEvent<Date> valueChangeEvent) {
-        FormUtilities.callOnChange(onChange);
-        String newValue = dateTimeFormat.format(mvDate.getValue());
-        mv.set("value", newValue);
-        if (mandatory && (newValue != null && !"".equals(newValue.trim()))) {
-          mvDate.removeStyleName("isWrong");
-        } else if (mandatory && (newValue == null || "".equals(newValue.trim()))) {
-          mvDate.addStyleName("isWrong");
-        }
-      }
-    });
-
-    mvDate.getTextBox().addValueChangeHandler(new ValueChangeHandler<String>() {
+    mvDate.addValueChangeHandler(new ValueChangeHandler<String>() {
       @Override
       public void onValueChange(ValueChangeEvent<String> event) {
         FormUtilities.callOnChange(onChange);
-        String value = event.getValue();
-        try {
-          Date date = dateTimeFormat.parse(value.trim());
-          mvDate.setValue(date);
-          mv.set("value", value);
-        } catch (IllegalArgumentException iae) {
-          if (event.getValue() == null || "".equals(event.getValue().trim())) {
-            mv.set("value", null);
-          }
-          mvDate.getTextBox().setValue(value);
+        String newValue = event.getValue();
+        if (newValue != null) {
+          newValue = newValue.trim();
+        }
+
+        mv.set("value", newValue == null || newValue.isEmpty() ? null : newValue);
+
+        if (mandatory && (newValue == null || newValue.isEmpty())) {
+          mvDate.addStyleName("isWrong");
+        } else {
+          mvDate.removeStyleName("isWrong");
         }
       }
     });

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/Humanize.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/common/client/tools/Humanize.java
@@ -12,6 +12,7 @@ import java.util.Date;
 import org.roda.core.data.common.RodaConstants;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JsDate;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.NumberFormat;
 import com.google.gwt.i18n.client.TimeZone;
@@ -44,6 +45,7 @@ public class Humanize {
   public static final DateTimeFormat DATE_TIME_FORMAT = DateTimeFormat.getFormat("yyyy-MM-dd HH:mm:ss z");
   public static final DateTimeFormat DATE_TIME_FORMAT_JSON = DateTimeFormat.getFormat("yyyy-MM-ddTHH:mm:ss.SSSZZZ");
   public static final boolean FORMAT_UTC = false;
+  private static final long CIVIL_DATE_UI_SAFE_TIME_SHIFT_MILLIS = 12 * 60 * 60 * 1000;
   public static final DateTimeFormat DATE_TIME_FORMAT_STRICT_UTC = DateTimeFormat
     .getFormat("yyyy-MM-dd HH:mm:ss 'UTC'");
   protected static final NumberFormat SMALL_NUMBER_FORMAT = NumberFormat.getFormat("0.#");
@@ -131,16 +133,16 @@ public class Humanize {
     if (dateInitial == null && dateFinal == null) {
       return extendedDate ? messages.titleDatesEmpty() : messages.simpleDatesEmpty();
     } else if (dateInitial != null && dateFinal == null) {
-      String dateInitialString = formatDate(dateInitial, extendedDate);
+      String dateInitialString = formatCivilDate(dateInitial, extendedDate);
       return extendedDate ? messages.titleDatesNoFinal(dateInitialString)
         : messages.simpleDatesNoFinal(dateInitialString);
     } else if (dateInitial == null) {
-      String dateFinalString = formatDate(dateFinal, extendedDate);
+      String dateFinalString = formatCivilDate(dateFinal, extendedDate);
       return extendedDate ? messages.titleDatesNoInitial(dateFinalString)
         : messages.simpleDatesNoInitial(dateFinalString);
     } else {
-      String dateInitialString = formatDate(dateInitial, extendedDate);
-      String dateFinalString = formatDate(dateFinal, extendedDate);
+      String dateInitialString = formatCivilDate(dateInitial, extendedDate);
+      String dateFinalString = formatCivilDate(dateFinal, extendedDate);
       return extendedDate ? messages.titleDates(dateInitialString, dateFinalString)
         : messages.simpleDates(dateInitialString, dateFinalString);
     }
@@ -242,7 +244,35 @@ public class Humanize {
       DATE_TIME_FORMAT);
   }
 
+  public static Date parseCivilDate(String civilDate) {
+    if (civilDate == null || civilDate.trim().isEmpty()) {
+      return null;
+    }
+
+    String[] parts = civilDate.trim().split("-");
+    if (parts.length != 3) {
+      return null;
+    }
+
+    int year = Integer.parseInt(parts[0]);
+    int month = Integer.parseInt(parts[1]);
+    int day = Integer.parseInt(parts[2]);
+
+    return new Date((long) JsDate.UTC(year, month - 1, day, 0, 0, 0, 0));
+  }
+
+  public static String formatCivilDate(Date date, boolean extended) {
+    String formatPropertyName = extended ? RodaConstants.UI_DATE_FORMAT_TITLE : RodaConstants.UI_DATE_FORMAT_SIMPLE;
+    Date displayDate = new Date(date.getTime() + CIVIL_DATE_UI_SAFE_TIME_SHIFT_MILLIS);
+    return applyDateTimeFormat(displayDate, ConfigurationManager.getString(formatPropertyName), DATE_FORMAT, true);
+  }
+
   private static String applyDateTimeFormat(Date date, String stringFormat, DateTimeFormat defaultValue) {
+    return applyDateTimeFormat(date, stringFormat, defaultValue, false);
+  }
+
+  private static String applyDateTimeFormat(Date date, String stringFormat, DateTimeFormat defaultValue,
+    boolean forceUtc) {
     DateTimeFormat format;
 
     if (stringFormat != null) {
@@ -262,7 +292,7 @@ public class Humanize {
       format = defaultValue;
     }
 
-    if (ConfigurationManager.getBoolean(FORMAT_UTC, RodaConstants.UI_DATE_TIME_FORMAT_UTC)) {
+    if (forceUtc || ConfigurationManager.getBoolean(FORMAT_UTC, RodaConstants.UI_DATE_TIME_FORMAT_UTC)) {
       return format.format(date, TimeZone.createTimeZone(0));
     }
 


### PR DESCRIPTION
- replace descriptive metadata DateBox usage with HTML5 date inputs backed by `yyyy-mm-dd` strings
- replace advanced search date DateBox inputs with HTML5 date inputs and convert values to UTC Date objects only when building filters
- apply a UI-only 12-hour render-time normalization for historical civil dates before UTC formatting
- adjust advanced search date input width so the browser date format remains visible
<img width="836" height="114" alt="image" src="https://github.com/user-attachments/assets/348abbee-1471-4ea3-84cb-78e42c9e6fd5" />
