### PR TITLE
Fix path traversal in job attachment download

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/JobService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/JobService.java
@@ -252,7 +252,7 @@ public class JobService {
     throws NotFoundException, GenericException {
     Path filePath = RodaCoreFactory.getJobAttachmentsDirectoryPath().resolve(jobId).resolve(attachmentId);
 
-    if (!filePath.startsWith(RodaCoreFactory.getJobAttachmentsDirectoryPath())) {
+    if (!RodaCoreFactory.checkPathIsWithin(filePath, RodaCoreFactory.getJobAttachmentsDirectoryPath())) {
       throw new GenericException("Attempt to retrieve files outside the permitted scope");
     }
 


### PR DESCRIPTION
## Issue

Snyk Code Analysis (SAST) flagged a **high-severity Path Traversal** finding in `JobsController.java` (`GET .../jobs/{id}/attachments/{attachment-id}` → `JobService.retrieveJobAttachment`).

`retrieveJobAttachment` builds the target file path from two request URL path variables (`jobId`, `attachmentId`) and attempts to guard against path traversal:

```java
Path filePath = RodaCoreFactory.getJobAttachmentsDirectoryPath().resolve(jobId).resolve(attachmentId);

if (!filePath.startsWith(RodaCoreFactory.getJobAttachmentsDirectoryPath())) {
  throw new GenericException("Attempt to retrieve files outside the permitted scope");
}
```

The problem: `Path.startsWith()` compares raw, unresolved path name-elements — it does **not** collapse `..` segments. An `attachmentId` such as `../../../../etc/passwd` produces a `Path` whose first segment is still literally the job-attachments directory, so `startsWith()` returns `true` even though the filesystem will resolve the `..` segments and escape the intended directory entirely once `Files.exists`/`Files.copy` run against it. This allows an authenticated user with access to this endpoint to read arbitrary files on the host filesystem (subject to OS file permissions of the running process).

This is a different bug from the `ConfigurationManager.getConfigurationFileAsStream` sink that several *other* Snyk Path Traversal findings in this scan route through — that one already calls `.normalize()`/`.toRealPath()` before its containment check and is safe.

## Fix

Swap the broken `startsWith` check for `RodaCoreFactory.checkPathIsWithin(Path, Path)`, the helper already used elsewhere in the codebase (e.g. `ConfigurationManager`) for exactly this kind of containment check — it normalizes/resolves the real path before comparing, so `..` segments can't bypass it.

## Testing

Verified `mvn -pl roda-ui/roda-wui -am compile` succeeds. This is a one-line, behavior-preserving change for all legitimate inputs (attachment ids without `..`); only traversal attempts are newly rejected.