### PR TITLE
Fix path traversal in transferred resources (download & upload)

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/common/monitor/TransferredResourcesScanner.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/monitor/TransferredResourcesScanner.java
@@ -119,7 +119,10 @@ public class TransferredResourcesScanner {
       parentPath = basePath;
     }
 
-    Path file = parentPath.resolve(fileName);
+    Path file = parentPath.resolve(fileName).normalize();
+    if (!RodaCoreFactory.checkPathIsWithin(file, parentPath)) {
+      throw new GenericException("Invalid file name: " + fileName);
+    }
     try {
       try {
         Files.createDirectories(parentPath);
@@ -143,8 +146,10 @@ public class TransferredResourcesScanner {
 
   public InputStream retrieveFile(String path) throws NotFoundException, RequestNotValidException, GenericException {
     InputStream ret;
-    Path p = basePath.resolve(path);
-    if (!FSUtils.exists(p)) {
+    Path p = basePath.resolve(path).normalize();
+    if (!RodaCoreFactory.checkPathIsWithin(p, basePath)) {
+      throw new RequestNotValidException("Requested path is outside the transferred resources folder: " + path);
+    } else if (!FSUtils.exists(p)) {
       throw new NotFoundException("File not found: " + path);
     } else if (!FSUtils.isFile(p)) {
       throw new RequestNotValidException("Requested file is not a regular file: " + path);
@@ -159,8 +164,10 @@ public class TransferredResourcesScanner {
   }
 
   public Path retrieveFilePath(String path) throws NotFoundException, RequestNotValidException, GenericException {
-    Path p = basePath.resolve(path);
-    if (!FSUtils.exists(p)) {
+    Path p = basePath.resolve(path).normalize();
+    if (!RodaCoreFactory.checkPathIsWithin(p, basePath)) {
+      throw new RequestNotValidException("Requested path is outside the transferred resources folder: " + path);
+    } else if (!FSUtils.exists(p)) {
       throw new NotFoundException("File not found: " + path);
     } else if (!FSUtils.isFile(p)) {
       throw new RequestNotValidException("Requested file is not a regular file: " + path);
@@ -169,7 +176,10 @@ public class TransferredResourcesScanner {
   }
 
   public boolean fileExists(String path) {
-    Path p = basePath.resolve(path);
+    Path p = basePath.resolve(path).normalize();
+    if (!RodaCoreFactory.checkPathIsWithin(p, basePath)) {
+      return false;
+    }
     return FSUtils.exists(p);
   }
 


### PR DESCRIPTION
## Issue

Snyk Code Analysis (SAST) flagged 2 **high-severity Path Traversal** findings in `TransferredResourceController.java`. Investigating the underlying `TransferredResourcesScanner` (roda-core) turned up the following:

- **`retrieveFile` / `retrieveFilePath` / `fileExists`** (backing `GET .../transferred-resources/{uuid}/download` and related endpoints): resolved the `path` argument directly against `basePath` with **no containment check at all** before reading from / checking existence of the resulting file — unlike sibling methods in the same class (`updateTransferredResources`, `updateTransferredResource`), which already validate containment. This is a real gap; confirmed true positive.
- The second Snyk finding (`Files.walkFileTree` in the reindex flow) turned out to be a **false positive** — that flow already resolves and validates the path via `RodaCoreFactory.checkPathIsWithin` in `updateTransferredResources` before `walkFileTree` ever runs on it. Snyk's taint tracker doesn't recognize that custom check as a sanitizer.
- While reviewing this file I found a **related, more directly exploitable bug in the same class that wasn't one of the 2 Snyk findings**: `createFile` (backing the resource **upload** endpoint) resolves the uploaded file's original filename (`MultipartFile.getOriginalFilename()`, fully attacker-controlled) against the parent directory with **zero sanitization** — unlike `createFolder`, which at least strips `/` from the folder name. An upload with a filename like `../../../../etc/cron.d/x` could write outside the transferred-resources directory. I've included the fix here since it's the same vulnerability class in the same file.

## Fix

Added `RodaCoreFactory.checkPathIsWithin()` containment checks (the same normalize-then-verify-containment helper already used elsewhere in this class and in `ConfigurationManager`) to `retrieveFile`, `retrieveFilePath`, `fileExists`, and `createFile`.

## Testing

Verified `mvn -pl roda-core/roda-core -am compile` succeeds. Behavior is unchanged for all legitimate relative paths/filenames; only traversal attempts are newly rejected (`RequestNotValidException`/`GenericException` for the read/write paths, `false` for `fileExists`).