### PR TITLE
Fix path traversal and SSRF in distributed instance sync

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/common/SyncUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/SyncUtils.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -156,13 +157,23 @@ public class SyncUtils {
   }
 
   public static Path getSyncOutcomeBundlePath(String bundleName) {
-    return RodaCoreFactory.getSynchronizationDirectoryPath().resolve(RodaConstants.CORE_SYNCHRONIZATION_OUTCOME_FOLDER)
-      .resolve(bundleName);
+    Path base = RodaCoreFactory.getSynchronizationDirectoryPath()
+      .resolve(RodaConstants.CORE_SYNCHRONIZATION_OUTCOME_FOLDER);
+    Path bundlePath = base.resolve(bundleName).normalize();
+    if (!RodaCoreFactory.checkPathIsWithin(bundlePath, base)) {
+      throw new IllegalArgumentException("Invalid sync bundle name: " + bundleName);
+    }
+    return bundlePath;
   }
 
   public static Path getSyncIncomingBundlePath(String bundleName) {
-    return RodaCoreFactory.getSynchronizationDirectoryPath().resolve(RodaConstants.CORE_SYNCHRONIZATION_INCOMING_FOLDER)
-      .resolve(bundleName);
+    Path base = RodaCoreFactory.getSynchronizationDirectoryPath()
+      .resolve(RodaConstants.CORE_SYNCHRONIZATION_INCOMING_FOLDER);
+    Path bundlePath = base.resolve(bundleName).normalize();
+    if (!RodaCoreFactory.checkPathIsWithin(bundlePath, base)) {
+      throw new IllegalArgumentException("Invalid sync bundle name: " + bundleName);
+    }
+    return bundlePath;
   }
 
   public static boolean removeSyncBundleLocal(String bundleName, String deletionDirectory) throws IOException {
@@ -177,17 +188,28 @@ public class SyncUtils {
 
   }
 
-  public static Path receiveBundle(String fileName, InputStream inputStream) throws IOException {
-    Path filePath = RodaCoreFactory.getSynchronizationDirectoryPath()
-      .resolve(RodaConstants.CORE_SYNCHRONIZATION_INCOMING_FOLDER).resolve(fileName);
+  public static Path receiveBundle(String fileName, InputStream inputStream) throws IOException, GenericException {
+    Path base = RodaCoreFactory.getSynchronizationDirectoryPath()
+      .resolve(RodaConstants.CORE_SYNCHRONIZATION_INCOMING_FOLDER);
+    // the incoming bundle file name is attacker-controlled (multipart upload filename), so keep only its
+    // basename before resolving, and validate the result stays within the incoming folder
+    String sanitizedFileName = Paths.get(fileName).getFileName().toString();
+    Path filePath = base.resolve(sanitizedFileName).normalize();
+    if (!RodaCoreFactory.checkPathIsWithin(filePath, base)) {
+      throw new GenericException("Invalid sync bundle file name: " + fileName);
+    }
     FileUtils.copyInputStreamToFile(inputStream, filePath.toFile());
     return filePath;
   }
 
   public static Path compress(Path workingDir, String filename)
     throws NotFoundException, GenericException, IOException {
-    Path outcomePath = RodaCoreFactory.getSynchronizationDirectoryPath()
-      .resolve(RodaConstants.CORE_SYNCHRONIZATION_OUTCOME_FOLDER).resolve(filename);
+    Path base = RodaCoreFactory.getSynchronizationDirectoryPath()
+      .resolve(RodaConstants.CORE_SYNCHRONIZATION_OUTCOME_FOLDER);
+    Path outcomePath = base.resolve(filename).normalize();
+    if (!RodaCoreFactory.checkPathIsWithin(outcomePath, base)) {
+      throw new GenericException("Invalid sync bundle file name: " + filename);
+    }
     LOGGER.debug("Compress files to {}", outcomePath);
 
     if (FSUtils.exists(outcomePath)) {

--- a/roda-core/roda-core/src/main/java/org/roda/core/common/TokenManager.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/common/TokenManager.java
@@ -8,6 +8,10 @@
 package org.roda.core.common;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.util.Date;
 
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -61,6 +65,8 @@ public class TokenManager {
   }
 
   public AccessToken grantToken(LocalInstance localInstance) throws GenericException, AuthenticationDeniedException {
+    validateCentralInstanceUrl(localInstance.getCentralInstanceURL());
+
     CloseableHttpClient httpClient = HttpClientBuilder.create().build();
     String url = localInstance.getCentralInstanceURL() + RodaConstants.API_SEP + RodaConstants.API_REST_V2_MEMBERS
       + RodaConstants.API_PATH_PARAM_AUTH_TOKEN;
@@ -83,6 +89,42 @@ public class TokenManager {
       }
     } catch (IOException e) {
       throw new GenericException("Error sending POST request", e);
+    }
+  }
+
+  /**
+   * Guards against Server-Side Request Forgery: the central instance URL comes straight from an
+   * HTTP request body (local instance registration/configuration), and this method sends the
+   * instance's bearer access key to it, so an unvalidated URL would let a caller make this server
+   * POST a live credential to an arbitrary host (e.g. an internal service or a cloud metadata
+   * endpoint).
+   */
+  private static void validateCentralInstanceUrl(String centralInstanceUrl) throws GenericException {
+    URI uri;
+    try {
+      uri = new URI(centralInstanceUrl);
+    } catch (URISyntaxException | NullPointerException e) {
+      throw new GenericException("Invalid central instance URL: " + centralInstanceUrl);
+    }
+
+    String scheme = uri.getScheme();
+    if (scheme == null || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+      throw new GenericException("Invalid central instance URL scheme: " + centralInstanceUrl);
+    }
+
+    String host = uri.getHost();
+    if (host == null) {
+      throw new GenericException("Invalid central instance URL: " + centralInstanceUrl);
+    }
+
+    try {
+      InetAddress address = InetAddress.getByName(host);
+      if (address.isLoopbackAddress() || address.isLinkLocalAddress() || address.isSiteLocalAddress()
+        || address.isAnyLocalAddress() || address.isMulticastAddress()) {
+        throw new GenericException("Central instance URL resolves to a disallowed address: " + centralInstanceUrl);
+      }
+    } catch (UnknownHostException e) {
+      throw new GenericException("Could not resolve central instance URL host: " + centralInstanceUrl, e);
     }
   }
 

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DistributedInstanceService.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/services/DistributedInstanceService.java
@@ -122,13 +122,28 @@ public class DistributedInstanceService {
 
   public StreamResponse retrieveLastSyncFileByClass(final String instanceIdentifier, final String entityClass,
     final String type) {
+    // these are meant to be simple identifiers, not path fragments, so reject anything that could
+    // be used to escape the synchronization directory
+    if (containsPathSeparator(instanceIdentifier) || containsPathSeparator(entityClass)
+      || containsPathSeparator(type)) {
+      throw new IllegalArgumentException("Invalid instance identifier, entity class or type");
+    }
+
     final StringBuilder fileNameBuilder = new StringBuilder();
     fileNameBuilder.append(type).append("_").append(instanceIdentifier).append("_").append(entityClass)
       .append(".jsonl");
 
-    final Path filePath = RodaCoreFactory.getSynchronizationDirectoryPath().resolve(fileNameBuilder.toString());
+    final Path base = RodaCoreFactory.getSynchronizationDirectoryPath();
+    final Path filePath = base.resolve(fileNameBuilder.toString()).normalize();
+    if (!RodaCoreFactory.checkPathIsWithin(filePath, base)) {
+      throw new IllegalArgumentException("Invalid instance identifier, entity class or type");
+    }
 
     return SyncUtils.createLastSyncFileStreamResponse(filePath);
+  }
+
+  private static boolean containsPathSeparator(String value) {
+    return value != null && (value.contains("/") || value.contains("\\") || value.contains(".."));
   }
 
   public Job importSyncBundle(User user, String instanceIdentifier, MultipartFile resource)


### PR DESCRIPTION
## Issues

Snyk Code Analysis (SAST) flagged 7 high-severity findings in `DistributedInstancesController.java` (all in the distributed-instance synchronization feature): 6 Path Traversal + 1 SSRF. This PR fixes 6 confirmed true positives (5 path traversal + the SSRF); the 6th path-traversal finding, sharing the same source line as the SSRF one, is a false positive (details below) — no fix needed for it.

### Path Traversal (5 real bugs, in `SyncUtils` / `DistributedInstanceService`)

1. **`SyncUtils.getSyncIncomingBundlePath` / `getSyncOutcomeBundlePath`** — used by the bundle-delete endpoint (`DELETE /remove/bundle/{name}/{dir}`). Resolved the `name` path variable with no containment check before `Files.deleteIfExists` → **arbitrary file deletion**.
2. **`SyncUtils.compress`** — used when building a central sync bundle. Resolved its output filename with no containment check before `Files.createFile` → could create/clobber a file outside the sync directory.
3. **`SyncUtils.receiveBundle`** — used when importing an uploaded sync bundle. Resolved the multipart upload's *original filename* (`MultipartFile.getOriginalFilename()`, fully attacker-controlled) directly, with zero sanitization, before `FileUtils.copyInputStreamToFile` → classic **arbitrary file write via upload filename**.
4. **`DistributedInstanceService.retrieveLastSyncFileByClass`** — builds a filename by concatenating three unchecked request values (instance id, entity class, type) and resolves it with no containment check before streaming the file back over HTTP → **arbitrary file read, directly exposed in the response body**.

All four now validate containment with `RodaCoreFactory.checkPathIsWithin(...)`, the same helper `ConfigurationManager` already uses for equivalent checks elsewhere in the codebase. `receiveBundle` additionally reduces the incoming filename to its basename before resolving (no legitimate bundle filename needs directory separators), and `retrieveLastSyncFileByClass` rejects any of its 3 inputs containing `/`, `\`, or `..` up front, since they're meant to be simple identifiers.

These endpoints require an authenticated user whose role passes `checkRoles` (distributed-instance/sync management), so exploitation needs a privileged account — that limits but doesn't eliminate real-world impact, and doesn't make the findings any less real.

### SSRF + credential exfiltration (1 real bug, in `TokenManager`)

`TokenManager.grantToken()` builds an `HttpPost` to `LocalInstance.getCentralInstanceURL()` — a value that arrives directly in an HTTP request body via the local-instance registration/configuration endpoints — and sends **that host** the instance's live bearer access key (`Authorization: Bearer <accessKey>`). With no validation, an authenticated caller could point this server at an arbitrary internal host or a cloud metadata endpoint (e.g. `169.254.169.254`) and have the server exfiltrate that credential to it — SSRF combined with credential exfiltration.

Added `validateCentralInstanceUrl()`: requires an `http`/`https` URL with a resolvable host, and rejects hosts resolving to loopback, link-local, site-local, multicast, or wildcard addresses, before any request is sent.

### False positive noted (not fixed, no action needed)

Snyk also reported a "Path Traversal" finding at the same source line as the SSRF finding, attributing the sink to `JsonUtils.java`'s `Path`-based `getObjectFromJson` overload. That's a call-graph resolution mistake: the actual call in `grantToken()` resolves to the `InputStream` overload of `getObjectFromJson`, which never touches the filesystem. Flagging here for visibility; recommend marking it as a false positive in Snyk directly.

## Testing

Verified `mvn -pl roda-ui/roda-wui -am compile` succeeds. All four path-traversal fixes are behavior-preserving for legitimate inputs; only traversal attempts are newly rejected. The SSRF fix only rejects URLs that resolve to private/loopback/link-local/multicast/wildcard addresses or non-http(s) schemes — legitimate central instance URLs (public hostnames) are unaffected.