### PR TITLE
Fix AccessKey authentication comparing raw token against its SHA-256 hash

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
@@ -22,6 +22,7 @@ import javax.crypto.SecretKey;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.cas.client.authentication.AttributePrincipal;
 import org.roda.core.RodaCoreFactory;
+import org.roda.core.common.CryptographyUtils;
 import org.roda.core.common.JwtUtils;
 import org.roda.core.data.common.RodaConstants;
 import org.roda.core.data.common.SecureString;
@@ -425,7 +426,7 @@ public class MembersController implements MembersRestService, Exportable {
       claims = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
       User user = RodaCoreFactory.getModelService().retrieveUser(claims.getSubject());
       AccessKeys accessKeys = RodaCoreFactory.getModelService().listAccessKeys();
-      AccessKey retAccessKey = accessKeys.getAccessKeyByKey(token);
+      AccessKey retAccessKey = accessKeys.getAccessKeyByKey(CryptographyUtils.hashTokenSHA256(token));
       if (retAccessKey != null) {
         AccessToken accessToken = new AccessToken();
         Date expirationDate = new Date(new Date().getTime() + RodaCoreFactory.getAccessTokenValidity());


### PR DESCRIPTION
## Summary
- `DefaultModelService.createAccessKey` stores the AccessKey's `key` as a one-way SHA-256 hash (introduced by #3621/#3622/#3623, commit 656e24701), but `MembersController.authenticate` (`POST /api/v2/members/token`) still looked up the incoming plaintext token directly via `AccessKeys.getAccessKeyByKey(token)` against that hashed value.
- Result: every correctly-signed AccessKey was rejected with "Access token not found" - the AccessKey→JWT exchange endpoint was completely broken for all callers.
- Fix: hash the incoming token the same way (`CryptographyUtils.hashTokenSHA256`) before the lookup, matching how it's stored.

## Test plan
- [x] Reproduced on a fresh RODA instance: created an AccessKey via `POST /api/v2/members/users/{id}/access-keys`, exchanged it via `POST /api/v2/members/token` - failed with "Access token not found" before this fix, succeeds (returns a valid JWT `AccessToken`) after.
- [x] Verified the JWT itself was always correctly signed (independently recomputed the HS256 signature) - the bug is purely in the hash-vs-plaintext lookup, not JWT signing/verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
