### PR TITLE
Fix generic /find and /count endpoints rejecting every request

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/config/JacksonConfig.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/config/JacksonConfig.java
@@ -18,6 +18,11 @@ public class JacksonConfig {
   public JsonMapper jsonMapper() {
     return JsonMapper.builder()
       // Prevents 400 errors when RestyGWT sends extra or unmapped type fields
-      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build();
+      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+      // Jackson 3's FAIL_ON_NULL_FOR_PRIMITIVES defaults to enabled (Jackson 2 had it
+      // disabled) - without this, any request DTO with a primitive @JsonCreator
+      // parameter (e.g. FindRequest/CountRequest's onlyActive) rejects every request
+      // that omits that field, breaking every generic /find and /count endpoint.
+      .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES).build();
   }
 }


### PR DESCRIPTION
## Summary
- Jackson 3's `DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES` defaults to **enabled** (Jackson 2 had it disabled) - an undocumented behavior change from the Jackson 3 migration.
- `FindRequest`/`CountRequest`'s `onlyActive` is a primitive `boolean` `@JsonCreator` parameter. Any request that omits it (i.e. every real caller, since it's meant to be optional) fails deserialization with `MismatchedInputException`, which Spring's default `HttpMessageNotReadable` handler turns into a generic `400 "Failed to read request"`.
- This broke **every** entity's `/find` and `/count` REST endpoint identically (confirmed on `/api/v2/aips/find` and `/api/v2/files/find` - not entity-specific).
- Fix: disable `FAIL_ON_NULL_FOR_PRIMITIVES` on the app's primary `JsonMapper` bean, restoring the Jackson-2-equivalent lenient behavior globally.

## Test plan
- [x] Reproduced by compiling `FindRequest` against the actual resolved Jackson 3.1.4 jars and feeding it `{}` - `MismatchedInputException` on the `onlyActive` creator parameter.
- [x] Confirmed live against a running RODA instance: `POST /api/v2/aips/find` with any body (including `{}`) returned 400 before this fix, 200 with correct results after.
- [x] Confirmed the same fix resolves `/api/v2/files/find` identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
