### PR TITLE
Fix SecureString not being Jackson-deserializable

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/config/JacksonConfig.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/config/JacksonConfig.java
@@ -1,10 +1,12 @@
 package org.roda.wui.config;
 
+import org.roda.core.data.common.SecureString;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 
 /**
  * @author Miguel Guimarães <mguimaraes@keep.pt>
@@ -16,6 +18,13 @@ public class JacksonConfig {
   @Bean
   @Primary
   public JsonMapper jsonMapper() {
+    SimpleModule secureStringModule = new SimpleModule();
+    // Custom (de)serializers for SecureString to support password fields in REST request DTOs.
+    // Without these, Jackson cannot deserialize JSON strings to SecureString, breaking every
+    // password-related REST v2 endpoint (createUser, registerUser, resetPassword, updateUser).
+    secureStringModule.addDeserializer(SecureString.class, new SecureStringDeserializer());
+    secureStringModule.addSerializer(SecureString.class, new SecureStringSerializer());
+
     return JsonMapper.builder()
       // Prevents 400 errors when RestyGWT sends extra or unmapped type fields
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
@@ -23,6 +32,7 @@ public class JacksonConfig {
       // disabled) - without this, any request DTO with a primitive @JsonCreator
       // parameter (e.g. FindRequest/CountRequest's onlyActive) rejects every request
       // that omits that field, breaking every generic /find and /count endpoint.
-      .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES).build();
+      .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+      .addModule(secureStringModule).build();
   }
 }

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/config/SecureStringDeserializer.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/config/SecureStringDeserializer.java
@@ -1,0 +1,37 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/keeps/roda
+ */
+package org.roda.wui.config;
+
+import org.roda.core.data.common.SecureString;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
+
+/**
+ * Custom Jackson deserializer for SecureString. Converts incoming JSON string values
+ * into SecureString instances by converting the string to a char array.
+ */
+public class SecureStringDeserializer extends StdDeserializer<SecureString> {
+
+  private static final long serialVersionUID = 1L;
+
+  public SecureStringDeserializer() {
+    super(SecureString.class);
+  }
+
+  @Override
+  public SecureString deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+    String value = p.getValueAsString();
+    if (value == null) {
+      return new SecureString();
+    }
+    return new SecureString(value.toCharArray());
+  }
+}

--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/config/SecureStringSerializer.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/config/SecureStringSerializer.java
@@ -1,0 +1,40 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/keeps/roda
+ */
+package org.roda.wui.config;
+
+import org.roda.core.data.common.SecureString;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * Custom Jackson serializer for SecureString. None of its use sites (password fields on
+ * request DTOs) are meant to be serialized back out, so this writes a fixed placeholder
+ * rather than the real value - only needed so the type has a symmetric module registration
+ * and doesn't fail if something incidentally serializes a request DTO (e.g. error handlers
+ * echoing a request body, audit logging).
+ */
+public class SecureStringSerializer extends StdSerializer<SecureString> {
+
+  private static final long serialVersionUID = 1L;
+
+  public SecureStringSerializer() {
+    super(SecureString.class);
+  }
+
+  @Override
+  public void serialize(SecureString value, JsonGenerator gen, SerializationContext provider) throws JacksonException {
+    if (value == null) {
+      gen.writeNull();
+    } else {
+      gen.writeString("***");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `SecureString` (the password field type on `CreateUserRequest`, `RegisterUserRequest`, `UpdateUserRequest`, `ResetPasswordRequest`) has no Jackson deserializer registered and no `String` constructor Jackson could use implicitly.
- Every JSON client hitting a password-related `/api/v2` endpoint got a `400 "Failed to read request"`, or a `500` (`NullPointerException` in `SecureString.toString()`, called unconditionally by `Pbkdf2PasswordEncoderImpl.encode`) if the password field was omitted entirely.
- Registers a `SimpleModule` with a custom deserializer/serializer for `SecureString`. The serializer never echoes the real password back out, writing a fixed `"***"` placeholder instead, since no legitimate code path needs the plaintext value serialized.

## Test plan
- [x] Compiles cleanly (`mvn -pl roda-ui/roda-wui -am compile`)
- [x] Verified live: created a user via `POST /api/v2/members/users` with a real `password` field, then authenticated as that user with HTTP Basic auth using the same password - confirming the full round trip through PBKDF2 hashing, LDAP storage, and LDAP bind.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>