### PR TITLE
Fix regenerateAccessKey putting the wrong subject in the JWT

### DIFF
--- a/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
+++ b/roda-ui/roda-wui/src/main/java/org/roda/wui/api/v2/controller/MembersController.java
@@ -460,7 +460,8 @@ public class MembersController implements MembersRestService, Exportable {
       }
 
       AccessKey accessKey = RodaCoreFactory.getModelService().retrieveAccessKey(id);
-      accessKey.setKey(JwtUtils.generateToken(accessKey.getName(), regenerateAccessKeyRequest.getExpirationDate()));
+      accessKey
+        .setKey(JwtUtils.generateToken(accessKey.getUserName(), regenerateAccessKeyRequest.getExpirationDate()));
       return RodaCoreFactory.getModelService().updateAccessKey(accessKey, requestContext.getUser().getName());
     } catch (RODAException e) {
       state = LogEntryState.FAILURE;


### PR DESCRIPTION
## Summary
- `accessKey.getName()` is the access key's human-readable label (e.g. "mcp"), not the RODA username - that's `accessKey.getUserName()`. `createAccessKey` correctly uses the username; `regenerateAccessKey` built the JWT inline and used the wrong field.
- The bug is silent and severe: `JwtUtils.generateToken` signs a token whose subject doesn't correspond to any real user. RODA's own `/authenticated` endpoint doesn't reject this - it decodes the token, fails to find a matching user, and returns a degenerate `User` shell (`id=null, name=null, uuid="user-null", guest=false, allRoles=[]`) with `200 OK` instead of erroring. Every downstream role check then silently sees a "real" but permission-less user rather than a clear authentication failure.
- Any AccessKey regenerated via RODA's UI (the Access Token tab's "regenerate" action, not "create") was affected - only brand-new keys worked correctly.

## Test plan
- [x] Compiles cleanly
- [x] Verified live: created an AccessKey, regenerated it via `POST /api/v2/members/users/access-keys/regenerate/{id}`, decoded the resulting JWT (`sub` now correctly the username, not the key's label), and confirmed `GET /api/v2/members/users/authenticated` with that token returns the full identity and role list.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>