### PR TITLE
Make semantic-search schema bootstrap opt-in (disabled by default)

### DIFF
--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/index/IndexServiceTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/index/IndexServiceTest.java
@@ -32,6 +32,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.request.schema.SchemaRequest;
+import org.apache.solr.client.solrj.response.schema.SchemaResponse.FieldsResponse;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsCollectionWithSize;
@@ -58,6 +60,7 @@ import org.roda.core.data.v2.index.sublist.Sublist;
 import org.roda.core.data.v2.ip.AIP;
 import org.roda.core.data.v2.ip.AIPState;
 import org.roda.core.data.v2.ip.IndexedAIP;
+import org.roda.core.data.v2.ip.IndexedFile;
 import org.roda.core.data.v2.ip.IndexedRepresentation;
 import org.roda.core.data.v2.ip.Permissions;
 import org.roda.core.data.v2.ip.Permissions.PermissionType;
@@ -811,5 +814,21 @@ public class IndexServiceTest {
     // check if none is repeated
     Set<String> set = new HashSet<>(results);
     Assert.assertEquals(results.size(), set.size());
+  }
+
+  @Test
+  public void testEmbeddingFieldsAbsentByDefault() throws Exception {
+    // core.index.embedding.enabled defaults to false: the AIP/File/Representation
+    // collections must not have the embedding_vector/vectorized_b fields declared.
+    for (String indexName : new String[] {SolrCollectionRegistry.getIndexName(IndexedAIP.class),
+      SolrCollectionRegistry.getIndexName(IndexedFile.class),
+      SolrCollectionRegistry.getIndexName(IndexedRepresentation.class)}) {
+      SchemaRequest.Fields fieldsRequest = new SchemaRequest.Fields();
+      FieldsResponse response = fieldsRequest.process(index.getSolrClient(), indexName);
+      Set<String> fieldNames = response.getFields().stream().map(f -> (String) f.get("name"))
+        .collect(Collectors.toSet());
+      MatcherAssert.assertThat(fieldNames, Matchers.not(Matchers.hasItem(RodaConstants.INDEX_EMBEDDING_VECTOR)));
+      MatcherAssert.assertThat(fieldNames, Matchers.not(Matchers.hasItem(RodaConstants.INDEX_VECTORIZED)));
+    }
   }
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/SolrBootstrapUtils.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/SolrBootstrapUtils.java
@@ -10,6 +10,7 @@ package org.roda.core.index.schema;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -39,6 +40,8 @@ public class SolrBootstrapUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(SolrBootstrapUtils.class);
   private static final String TEXT_TO_VECTOR_MODEL_STORE_PATH = "/schema/text-to-vector-model-store";
   private static final String LANGCHAIN4J_OPENAI_MODEL_CLASS = "dev.langchain4j.model.openai.OpenAiEmbeddingModel";
+  private static final Set<String> EMBEDDING_FIELD_NAMES = Set.of(RodaConstants.INDEX_EMBEDDING_VECTOR,
+    RodaConstants.INDEX_VECTORIZED);
 
   private static Map<String, Field> getFields(SolrClient client, String collectionName) throws GenericException {
 
@@ -87,8 +90,21 @@ public class SolrBootstrapUtils {
     Map<String, DynamicField> dynamicFields = getDynamicFields(client, collection.getIndexName());
     Set<CopyField> copyFields = getCopyFields(client, collection.getIndexName());
 
+    boolean embeddingEnabled = Boolean
+      .parseBoolean(RodaCoreFactory.getRodaConfigurationAsString(RodaConstants.CORE_INDEX_EMBEDDING_ENABLED));
+
+    // Semantic search (embedding_vector/vectorized_b) is opt-in: skip both fields
+    // entirely on bootstrap unless core.index.embedding.enabled=true, so fresh
+    // instances get no explicit vector schema fields by default. Filtering by
+    // name (not by Field.TYPE_KNN_VECTOR) is required: vectorized_b is a plain
+    // boolean field and wouldn't otherwise be caught by a type-based check, but
+    // both fields must be gated together. See registerTextToVectorModel below
+    // for the separately-gated query-time model registration.
+    List<Field> collectionFields = collection.getFields().stream()
+      .filter(f -> embeddingEnabled || !EMBEDDING_FIELD_NAMES.contains(f.getName())).collect(Collectors.toList());
+
     SchemaBuilder b = new SchemaBuilder();
-    collection.getFields().forEach(f -> {
+    collectionFields.forEach(f -> {
       if (!fields.containsKey(f.getName())) {
         b.addField(f);
       } else if (!fields.get(f.getName()).isEquivalentTo(f)) {
@@ -123,8 +139,7 @@ public class SolrBootstrapUtils {
       LOGGER.info("Collection {} is up to date", collection.getIndexName());
     }
 
-    boolean hasVectorField = collection.getFields().stream()
-      .anyMatch(f -> Field.TYPE_KNN_VECTOR.equals(f.getType()));
+    boolean hasVectorField = collectionFields.stream().anyMatch(f -> Field.TYPE_KNN_VECTOR.equals(f.getType()));
     if (hasVectorField) {
       registerTextToVectorModel(client, collection.getIndexName());
     }

--- a/roda-core/roda-core/src/main/resources/config/roda-core.properties
+++ b/roda-core/roda-core/src/main/resources/config/roda-core.properties
@@ -282,16 +282,26 @@ core.notification.package = org.roda.core.plugins.base.notifications
 ##########################################################################
 # Semantic/vector search settings
 #
-# Configures Solr's text-to-vector module (query-time only - RODA does not
-# generate embeddings itself). When enabled, RODA
-# registers "solr_model" in Solr's text-to-vector-model-store on bootstrap,
+# Configures Solr's text-to-vector module for semantic search (query-time
+# only - RODA does not generate embeddings itself). Disabled by default: on
+# a fresh instance, the AIP/File/Representation Solr collections are
+# bootstrapped WITHOUT the embedding_vector/vectorized_b schema fields, and
+# no text-to-vector model is registered. When enabled, RODA additionally
+# creates the embedding_vector (knn_vector) and vectorized_b fields on
+# bootstrap, and registers "solr_model" in Solr's text-to-vector-model-store,
 # pointing at an external OpenAI-compatible embeddings API. The vectors
 # themselves are written by a separate, external enrichment service on an
 # asynchronous second pass, matching (name, dimensions) below.
 #
+# Enabling this on an instance that has already been bootstrapped with it
+# disabled takes effect on the next RODA restart (the fields are added at
+# that point); RODA does not currently support removing/pruning schema
+# fields on a later disable.
+#
 # Usage:
 #
-# * enabled: <Boolean> whether to register the text-to-vector model on bootstrap
+# * enabled: <Boolean> whether to create the embedding_vector/vectorized_b
+#		schema fields and register the text-to-vector model on bootstrap
 # * base_url: <String> OpenAI-compatible embeddings API base URL (e.g. a local model server)
 # * api_key: <String> optional API key for the embeddings API
 # * model_name: <String> model name to request from the embeddings API


### PR DESCRIPTION
## Summary
- RODA's Solr schema bootstrap always created the `embedding_vector` (`knn_vector`) and `vectorized_b` fields on the AIP/File/Representation collections of every instance, regardless of configuration.
- The existing `core.index.embedding.enabled` flag (already default `false`) already gated query-time model registration, but not this schema field creation step, so a fresh instance always ended up with the vector schema footprint anyway.
- Reuses the same flag (no new config key) to also gate field creation in `SolrBootstrapUtils.bootstrapCollection` - when disabled (the default), both fields are filtered out by name before schema-diffing. Filtering by name rather than `Field.TYPE_KNN_VECTOR` is required since `vectorized_b` is a plain boolean field with no type-based signal tying it to `embedding_vector`.
- Enabling the flag on an already-bootstrapped instance takes effect on the next restart, matching the pre-existing behavior (bootstrap has never supported pruning fields on a later disable).

## Changes
- `SolrBootstrapUtils.java`: gate `embedding_vector`/`vectorized_b` field creation behind `core.index.embedding.enabled`.
- `roda-core.properties`: updated the doc comment to reflect that `enabled` now also gates schema field creation.
- `IndexServiceTest.java`: new regression test asserting both fields are absent from all three collections under default config.

## Test plan
- [x] `mvn compile`/`test-compile` clean
- [x] `IndexServiceTest` run against a real embedded Solr/Zookeeper (via `RodaContainersLifecycleListener`) - 18/18 passed, including the new test
- [x] Rebuilt `keeps/roda:development` image from this branch, ran it via `deploys/standalone/docker-compose-e2e.yaml`: RODA healthy, real REST API calls (auth, AIP create) succeed, and Solr's `/schema/fields` confirms `embedding_vector`/`vectorized_b` are absent by default