### PR TITLE
Enable advanced search (level filter) on the AIP select dialog

### DIFF
--- a/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
+++ b/roda-ui/roda-wui/src/main/resources/config/roda-wui.properties
@@ -977,6 +977,7 @@ ui.lists.RepresentationInformationNetwork_RI.search.advanced.enabled = true
 ui.lists.Search_AIPs.search.advanced.enabled = true
 ui.lists.Search_files.search.advanced.enabled = true
 ui.lists.Search_representations.search.advanced.enabled = true
+ui.lists.SelectAipDialog_AIPs.search.advanced.enabled = true
 ui.lists.UserLog_logEntries.search.advanced.enabled = true
 ui.lists.AuditLogs_triggeredLogs.search.advanced.enabled = true
 ui.lists.BrowseAIPPortal_aipChildren.search.advanced.enabled = true


### PR DESCRIPTION
## Summary
- The AIP parent/node picker (`SelectAipDialog`, list id `SelectAipDialog_AIPs`) previously only offered plain text search, making it hard to pick a parent at a specific level of description during ingest.
- This dialog is shared by several actions, all of which benefit: ingest's "Parent node" job parameter, the "Move" AIP action, the Disposal Rule parent picker, and the Representation Information linking dialog.
- Enables `ui.lists.SelectAipDialog_AIPs.search.advanced.enabled = true`, which turns on the existing "Advanced search" panel for this list, reusing the already-configured `Level` field for `IndexedAIP` (no other code changes needed).

## Test plan
- [ ] `mvn install -Pcore -DskipTests` then `mvn -pl roda-ui/roda-wui -am spring-boot:run -Pdebug-main`
- [ ] Start an ingest job with a "Parent node" parameter and confirm the picker now shows an "Advanced search" toggle with a "Level" field that filters results
- [ ] Confirm the same "Advanced search" panel appears when using "Move" on an AIP, selecting a Disposal Rule parent, and linking Representation Information

https://claude.ai/code/session_01RktowM99pwWfguG3s84aHM