### PR TITLE
Defer job/report DB cleanup after flush to storage to avoid ingest slowdown

### DIFF
--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/JsonUtils.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/utils/JsonUtils.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.io.IOUtils;
 import org.roda.core.data.exceptions.GenericException;
@@ -47,6 +48,26 @@ public final class JsonUtils {
   private static final String JSON_ERROR_MESSAGE = "Error while parsing JSON";
   private static final String ERROR_TRANSFORMING_OBJECT_TO_JSON_STRING = "Error transforming object '{}' to json string";
 
+  // Jackson mappers are expensive to build (introspection, module registration)
+  // but are thread-safe for concurrent reads/writes once configured, so they
+  // are built once and reused rather than per call -- building one per call
+  // was measured to dominate the cost of hydrating rows with JSON-converted
+  // columns (e.g. Report.reports, Report.sourceObjectOriginalIds).
+  private static final JsonMapper PLAIN_MAPPER = JsonMapper.builder().build();
+  private static final JsonMapper DEFAULT_FILTERS_MAPPER = createJsonMapperBuilder().build();
+  private static final JsonMapper NON_EMPTY_MAPPER = createJsonMapperBuilder()
+    .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_EMPTY)).build();
+
+  // getJsonFromObject(Object, Class) needs a mapper configured with a mixin
+  // combination that depends on the object's runtime type; that combination is
+  // drawn from a small, bounded set, so mappers are built once per combination
+  // and cached rather than rebuilt on every call.
+  private record MixinCacheKey(boolean descriptiveMetadataMixin, boolean technicalMetadataMixin, Class<?> mixin,
+    Class<?> mixinTarget) {
+  }
+
+  private static final ConcurrentHashMap<MixinCacheKey, JsonMapper> MIXIN_MAPPER_CACHE = new ConcurrentHashMap<>();
+
   private JsonUtils() {
     // do nothing
   }
@@ -60,8 +81,7 @@ public final class JsonUtils {
   }
 
   public static byte[] toByteArray(Object object) {
-    JsonMapper mapper = createJsonMapperBuilder().build();
-    return mapper.writeValueAsBytes(object);
+    return DEFAULT_FILTERS_MAPPER.writeValueAsBytes(object);
   }
 
   public static <T> T readObjectFromFile(Path jsonFile, Class<T> objectClass) throws GenericException {
@@ -95,8 +115,7 @@ public final class JsonUtils {
   public static Map<String, String> getMapFromJson(String json) {
     Map<String, String> ret = new HashMap<>();
     try {
-      JsonMapper mapper = JsonMapper.builder().build();
-      ret = mapper.readValue(json, new TypeReference<Map<String, String>>() {});
+      ret = PLAIN_MAPPER.readValue(json, new TypeReference<Map<String, String>>() {});
     } catch (JacksonException e) {
       LOGGER.error("Error transforming json string to Map<String,String>", e);
     }
@@ -110,10 +129,7 @@ public final class JsonUtils {
   public static String getJsonFromObject(Object object, Class<?> mixin) {
     String ret = null;
     try {
-      JsonMapper.Builder builder = createJsonMapperBuilder();
-      addMixinsToBuilder(builder, object, mixin);
-      JsonMapper mapper = builder.build();
-
+      JsonMapper mapper = getMapperForMixins(object, mixin);
       ret = mapper.writeValueAsString(object);
     } catch (JacksonException e) {
       LOGGER.error(ERROR_TRANSFORMING_OBJECT_TO_JSON_STRING, object, e);
@@ -129,11 +145,7 @@ public final class JsonUtils {
           ret.append("\n");
         }
 
-        JsonMapper mapper = createJsonMapperBuilder()
-                .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_EMPTY))
-                .build();
-
-        ret.append(mapper.writer().writeValueAsString(object));
+        ret.append(NON_EMPTY_MAPPER.writer().writeValueAsString(object));
       } catch (JacksonException e) {
         LOGGER.error(ERROR_TRANSFORMING_OBJECT_TO_JSON_STRING, object, e);
       }
@@ -141,30 +153,50 @@ public final class JsonUtils {
     return ret.toString();
   }
 
-  private static void addMixinsToBuilder(JsonMapper.Builder builder, Object object, Class<?> mixin) {
-    if (!(object instanceof DescriptiveMetadata)) {
-      if (object instanceof List<?> objectList) {
-        if (!objectList.isEmpty() && !(objectList.getFirst() instanceof DescriptiveMetadata)) {
-          builder.addMixIn(DescriptiveMetadata.class, DescriptiveMetadataMixIn.class);
-        }
-      } else {
-        builder.addMixIn(DescriptiveMetadata.class, DescriptiveMetadataMixIn.class);
-      }
+  private static JsonMapper getMapperForMixins(Object object, Class<?> mixin) {
+    boolean needsDescriptiveMetadataMixin = needsDescriptiveMetadataMixin(object);
+    boolean needsTechnicalMetadataMixin = needsTechnicalMetadataMixin(object);
+    Class<?> mixinTarget = mixin != null ? object.getClass() : null;
+    MixinCacheKey key = new MixinCacheKey(needsDescriptiveMetadataMixin, needsTechnicalMetadataMixin, mixin,
+      mixinTarget);
+
+    return MIXIN_MAPPER_CACHE.computeIfAbsent(key, JsonUtils::buildMapperForMixins);
+  }
+
+  private static JsonMapper buildMapperForMixins(MixinCacheKey key) {
+    JsonMapper.Builder builder = createJsonMapperBuilder();
+
+    if (key.descriptiveMetadataMixin()) {
+      builder.addMixIn(DescriptiveMetadata.class, DescriptiveMetadataMixIn.class);
+    }
+    if (key.technicalMetadataMixin()) {
+      builder.addMixIn(TechnicalMetadata.class, TechnicalMetadataMixIn.class);
+    }
+    if (key.mixin() != null) {
+      builder.addMixIn(key.mixinTarget(), key.mixin());
     }
 
-    if (!(object instanceof TechnicalMetadata)) {
-      if (object instanceof List<?> objectList) {
-        if (!objectList.isEmpty() && !(objectList.getFirst() instanceof TechnicalMetadata)) {
-          builder.addMixIn(TechnicalMetadata.class, TechnicalMetadataMixIn.class);
-        }
-      } else {
-        builder.addMixIn(TechnicalMetadata.class, TechnicalMetadataMixIn.class);
-      }
-    }
+    return builder.build();
+  }
 
-    if (mixin != null) {
-      builder.addMixIn(object.getClass(), mixin);
+  private static boolean needsDescriptiveMetadataMixin(Object object) {
+    if (object instanceof DescriptiveMetadata) {
+      return false;
     }
+    if (object instanceof List<?> objectList) {
+      return !objectList.isEmpty() && !(objectList.getFirst() instanceof DescriptiveMetadata);
+    }
+    return true;
+  }
+
+  private static boolean needsTechnicalMetadataMixin(Object object) {
+    if (object instanceof TechnicalMetadata) {
+      return false;
+    }
+    if (object instanceof List<?> objectList) {
+      return !objectList.isEmpty() && !(objectList.getFirst() instanceof TechnicalMetadata);
+    }
+    return true;
   }
 
   public static <T> T getObjectFromJson(Path json, Class<T> objectClass) throws GenericException {
@@ -197,8 +229,7 @@ public final class JsonUtils {
 
   public static <T> T getObjectFromJson(String json, Class<T> objectClass) throws GenericException {
     try {
-      JsonMapper mapper = JsonMapper.builder().build();
-      return mapper.readValue(json, objectClass);
+      return PLAIN_MAPPER.readValue(json, objectClass);
     } catch (JacksonException e) {
       throw new GenericException(JSON_ERROR_MESSAGE, e);
     }
@@ -221,9 +252,8 @@ public final class JsonUtils {
 
   public static <T> List<T> getListFromJson(String json, Class<T> objectClass) throws GenericException {
     try {
-      JsonMapper mapper = JsonMapper.builder().build();
-      TypeFactory t = mapper.getTypeFactory();
-      return mapper.readValue(json, t.constructCollectionType(ArrayList.class, objectClass));
+      TypeFactory t = PLAIN_MAPPER.getTypeFactory();
+      return PLAIN_MAPPER.readValue(json, t.constructCollectionType(ArrayList.class, objectClass));
     } catch (JacksonException e) {
       throw new GenericException(JSON_ERROR_MESSAGE, e);
     }
@@ -231,8 +261,7 @@ public final class JsonUtils {
 
   public static JsonNode parseJson(String json) throws GenericException {
     try {
-      JsonMapper mapper = JsonMapper.builder().build();
-      return mapper.readTree(json);
+      return PLAIN_MAPPER.readTree(json);
     } catch (JacksonException e) {
       throw new GenericException(JSON_ERROR_MESSAGE, e);
     }
@@ -240,8 +269,7 @@ public final class JsonUtils {
 
   public static JsonNode parseJson(InputStream json) throws GenericException {
     try {
-      JsonMapper mapper = JsonMapper.builder().build();
-      return mapper.readTree(json);
+      return PLAIN_MAPPER.readTree(json);
     } catch (JacksonException e) {
       throw new GenericException(JSON_ERROR_MESSAGE, e);
     } finally {
@@ -252,8 +280,7 @@ public final class JsonUtils {
   public static String getJsonFromNode(JsonNode node) {
     String ret = null;
     try {
-      JsonMapper mapper = createJsonMapperBuilder().build();
-      ret = mapper.writeValueAsString(node);
+      ret = DEFAULT_FILTERS_MAPPER.writeValueAsString(node);
     } catch (JacksonException e) {
       LOGGER.error(ERROR_TRANSFORMING_OBJECT_TO_JSON_STRING, node, e);
     }

--- a/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Job.java
+++ b/roda-common/roda-common-data/src/main/java/org/roda/core/data/v2/jobs/Job.java
@@ -85,6 +85,11 @@ public class Job implements IsModelObject, HasId, HasInstanceID, HasInstanceName
   // job state details
   @Column(name = "state_details", columnDefinition = "TEXT")
   private String stateDetails = "";
+  // moment the job (and its reports) were flushed to file storage; null while
+  // the job is still running or hasn't been picked up by the flush cleanup task
+  @Column(name = "flushed_at")
+  @Temporal(TemporalType.TIMESTAMP)
+  private Date flushedAt = null;
 
   // job instance id
   @Column(name = "instance_id")
@@ -255,6 +260,14 @@ public class Job implements IsModelObject, HasId, HasInstanceID, HasInstanceName
 
   public void setStateDetails(String stateDetails) {
     this.stateDetails = stateDetails;
+  }
+
+  public Date getFlushedAt() {
+    return flushedAt;
+  }
+
+  public void setFlushedAt(Date flushedAt) {
+    this.flushedAt = flushedAt;
   }
 
   public JobStats getJobStats() {

--- a/roda-core/roda-core-tests/src/main/java/org/roda/core/model/JobPersistenceTest.java
+++ b/roda-core/roda-core-tests/src/main/java/org/roda/core/model/JobPersistenceTest.java
@@ -35,6 +35,7 @@ import org.roda.core.data.v2.jobs.Job;
 import org.roda.core.data.v2.jobs.Job.JOB_STATE;
 import org.roda.core.data.v2.jobs.PluginType;
 import org.roda.core.data.v2.jobs.Report;
+import org.roda.core.repository.job.JobFlushCleanupTask;
 import org.roda.core.repository.job.JobRepository;
 import org.roda.core.repository.job.ReportRepository;
 import org.roda.core.security.LdapUtilityTestHelper;
@@ -71,6 +72,9 @@ public class JobPersistenceTest extends AbstractTestNGSpringContextTests {
 
   @Autowired
   private ReportRepository reportRepository;
+
+  @Autowired
+  private JobFlushCleanupTask jobFlushCleanupTask;
 
   @BeforeClass
   public void init() throws IOException, GenericException {
@@ -130,8 +134,9 @@ public class JobPersistenceTest extends AbstractTestNGSpringContextTests {
   }
 
   /**
-   * Test that updating a job to a final state (COMPLETED) flushes it from the database
-   * to file storage.
+   * Test that updating a job to a final state (COMPLETED) flushes it to file
+   * storage immediately, while its DB row (and its reports) are only marked as
+   * flushed -- actual DB removal is deferred to {@link JobFlushCleanupTask}.
    */
   @Test
   public void testJobFinalization() throws RODAException {
@@ -157,16 +162,32 @@ public class JobPersistenceTest extends AbstractTestNGSpringContextTests {
     job.setEndDate(new Date());
     model.createOrUpdateJob(job);
 
-    // Verify job is no longer in database (flushed to storage)
-    assertFalse(jobRepository.existsById(jobId), "Job should not exist in database after completion");
+    // Job row still exists right after flush -- deletion is deferred -- but is
+    // now marked as flushed
+    assertTrue(jobRepository.existsById(jobId), "Job row should still exist in database right after flush");
+    assertNotNull(jobRepository.findById(jobId).orElseThrow().getFlushedAt(),
+      "Job should be marked as flushed right after flush");
 
-    // Verify report is no longer in database
-    assertFalse(reportRepository.existsById(report.getId()), "Report should not exist in database after job completion");
+    // Report row is likewise still present right after flush
+    assertTrue(reportRepository.existsById(report.getId()), "Report row should still exist right after flush");
 
-    // Verify job can still be retrieved (from storage)
+    // Job can be retrieved with its up-to-date final state (not stale), whether
+    // read from the still-present DB row or, after cleanup, from storage
     Job retrievedJob = model.retrieveJob(jobId);
-    assertNotNull(retrievedJob, "Should be able to retrieve completed job from storage");
+    assertNotNull(retrievedJob, "Should be able to retrieve the completed job");
     assertEquals(retrievedJob.getState(), JOB_STATE.COMPLETED);
+
+    // Running the cleanup task now removes the flushed job and its reports
+    jobFlushCleanupTask.cleanFlushedJobs();
+
+    assertFalse(jobRepository.existsById(jobId), "Job should be removed from database after cleanup runs");
+    assertFalse(reportRepository.existsById(report.getId()),
+      "Report should be removed from database after cleanup runs");
+
+    // Job is still retrievable, now from storage
+    Job retrievedAfterCleanup = model.retrieveJob(jobId);
+    assertNotNull(retrievedAfterCleanup, "Should be able to retrieve completed job from storage after cleanup");
+    assertEquals(retrievedAfterCleanup.getState(), JOB_STATE.COMPLETED);
 
     // Clean up
     model.deleteJob(jobId);

--- a/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultModelService.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/model/DefaultModelService.java
@@ -41,6 +41,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
@@ -2987,9 +2992,23 @@ public class DefaultModelService implements ModelService {
     notifyJobCreatedOrUpdated(job, false).failOnError();
   }
 
+  // Bound on how many reports of a single job are flushed to storage
+  // concurrently. Reports across different jobs are already flushed
+  // concurrently by the orchestrator (one flush call per finishing job); this
+  // only parallelizes the (potentially many) reports of one job.
+  private static final int JOB_REPORT_FLUSH_PARALLELISM = 8;
+
   /**
    * Flushes a job and its reports from the database to the file storage. This
    * method is called when a job reaches a final state.
+   *
+   * The job row is only marked as flushed here (its {@code flushedAt} field is
+   * set), not deleted: deleting it (and its reports) immediately would mean one
+   * extra DELETE statement/transaction per
+   * job, which becomes a bottleneck when many jobs finish around the same time
+   * (e.g. many SIPs being ingested concurrently) and compete with live ingest
+   * traffic for database connections and locks. The actual row removal is done
+   * later, in batches, by {@link JobFlushCleanupTask}.
    */
   private void flushJobToStorage(Job job)
     throws RequestNotValidException, GenericException, NotFoundException, AuthorizationDeniedException {
@@ -3001,19 +3020,68 @@ public class DefaultModelService implements ModelService {
     // Flush all reports for this job from DB to storage
     if (getReportRepository() != null) {
       List<Report> dbReports = getReportRepository().findByJobId(job.getId());
-      for (Report report : dbReports) {
-        String reportAsJson = JsonUtils.getJsonFromObject(report);
-        StoragePath reportPath = ModelUtils.getJobReportStoragePath(report.getJobId(), report.getId());
-        storage.updateBinaryContent(reportPath, new StringContentPayload(reportAsJson), false, true, false, null);
+      if (!dbReports.isEmpty()) {
+        flushReportsToStorage(dbReports);
       }
-      // Delete reports from DB
-      getReportRepository().deleteByJobId(job.getId());
     }
 
-    // Delete job from DB
+    // Mark job as flushed and persist its final state; actual DB cleanup (job +
+    // reports) happens later, in batches, via JobFlushCleanupTask. The full
+    // entity is saved here (not a partial "set flushedAt" update) so that a
+    // read of the DB row in the window before cleanup runs (e.g. via
+    // retrieveJob/listJobReports) still reflects the job's final state.
     JobRepository jobRepo = getJobRepository();
-    if (jobRepo != null && jobRepo.existsById(job.getId())) {
-      jobRepo.deleteById(job.getId());
+    if (jobRepo != null) {
+      job.setFlushedAt(new Date());
+      jobRepo.save(job);
+    }
+  }
+
+  /**
+   * Writes each report's JSON representation to file storage, in parallel
+   * (bounded by {@link #JOB_REPORT_FLUSH_PARALLELISM}), since storage I/O
+   * latency -- not database access -- dominates the cost of flushing a job with
+   * many reports.
+   */
+  private void flushReportsToStorage(List<Report> dbReports)
+    throws RequestNotValidException, GenericException, NotFoundException, AuthorizationDeniedException {
+    int parallelism = Math.min(dbReports.size(), JOB_REPORT_FLUSH_PARALLELISM);
+    ExecutorService executor = Executors.newFixedThreadPool(parallelism);
+    try {
+      List<Future<Void>> futures = new ArrayList<>(dbReports.size());
+      for (Report report : dbReports) {
+        Callable<Void> task = () -> {
+          String reportAsJson = JsonUtils.getJsonFromObject(report);
+          StoragePath reportPath = ModelUtils.getJobReportStoragePath(report.getJobId(), report.getId());
+          storage.updateBinaryContent(reportPath, new StringContentPayload(reportAsJson), false, true, false, null);
+          return null;
+        };
+        futures.add(executor.submit(task));
+      }
+
+      for (Future<Void> future : futures) {
+        try {
+          future.get();
+        } catch (ExecutionException e) {
+          Throwable cause = e.getCause();
+          if (cause instanceof RequestNotValidException requestNotValidException) {
+            throw requestNotValidException;
+          } else if (cause instanceof NotFoundException notFoundException) {
+            throw notFoundException;
+          } else if (cause instanceof AuthorizationDeniedException authorizationDeniedException) {
+            throw authorizationDeniedException;
+          } else if (cause instanceof GenericException genericException) {
+            throw genericException;
+          } else {
+            throw new GenericException("Error flushing job report to storage", cause);
+          }
+        }
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new GenericException("Interrupted while flushing job reports to storage", e);
+    } finally {
+      executor.shutdown();
     }
   }
 

--- a/roda-core/roda-core/src/main/java/org/roda/core/repository/job/JobFlushCleanupTask.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/repository/job/JobFlushCleanupTask.java
@@ -1,0 +1,84 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/keeps/roda
+ */
+package org.roda.core.repository.job;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.roda.core.data.v2.jobs.Job;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduled task responsible for removing jobs (and their reports) from the
+ * database once they have already been flushed to file storage.
+ *
+ * {@code DefaultModelService.flushJobToStorage} only writes the job/reports
+ * to storage and marks the job row with {@code flushedAt} -- it deliberately
+ * does not delete anything, since deleting one job at a time (one DELETE per
+ * job, each its own transaction) becomes a bottleneck when many jobs finish
+ * around the same time (e.g. many SIPs being ingested concurrently), each
+ * competing with live ingest traffic for database connections and locks.
+ *
+ * This task instead removes flushed jobs in batches, on a fixed schedule,
+ * decoupled from the ingest hot path. Because the storage flush already
+ * happened before a job is marked {@code flushedAt}, a job left behind by a
+ * crash before this task runs is simply picked up on the next run -- no data
+ * is at risk.
+ *
+ * @author RODA Development Team
+ */
+@Component
+public class JobFlushCleanupTask {
+  private static final Logger LOGGER = LoggerFactory.getLogger(JobFlushCleanupTask.class);
+
+  private final JobRepository jobRepository;
+  private final ReportRepository reportRepository;
+
+  @Value("${jobs.flush-cleanup.batch-size:500}")
+  private int batchSize;
+
+  public JobFlushCleanupTask(JobRepository jobRepository, ReportRepository reportRepository) {
+    this.jobRepository = jobRepository;
+    this.reportRepository = reportRepository;
+  }
+
+  @Scheduled(fixedDelayString = "${jobs.flush-cleanup.interval.millis:60000}")
+  public void cleanFlushedJobs() {
+    Pageable batch = PageRequest.of(0, batchSize);
+    int totalCleaned = 0;
+
+    List<Job> flushedJobs = jobRepository.findByFlushedAtIsNotNull(batch);
+    while (!flushedJobs.isEmpty()) {
+      List<String> jobIds = flushedJobs.stream().map(Job::getId).collect(Collectors.toList());
+
+      try {
+        reportRepository.deleteByJobIdIn(jobIds);
+        jobRepository.deleteAllByIdInBatch(jobIds);
+        totalCleaned += jobIds.size();
+      } catch (Exception e) {
+        LOGGER.error("Error cleaning up flushed jobs from the database", e);
+        break;
+      }
+
+      if (jobIds.size() < batchSize) {
+        break;
+      }
+      flushedJobs = jobRepository.findByFlushedAtIsNotNull(batch);
+    }
+
+    if (totalCleaned > 0) {
+      LOGGER.info("Cleaned up {} flushed jobs (and their reports) from the database", totalCleaned);
+    }
+  }
+}

--- a/roda-core/roda-core/src/main/java/org/roda/core/repository/job/JobRepository.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/repository/job/JobRepository.java
@@ -7,7 +7,10 @@
  */
 package org.roda.core.repository.job;
 
+import java.util.List;
+
 import org.roda.core.data.v2.jobs.Job;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -19,5 +22,14 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface JobRepository extends JpaRepository<Job, String> {
-  // Standard JPA methods are inherited from JpaRepository
+
+  /**
+   * Finds a page of jobs that have already been flushed to file storage and are
+   * therefore eligible for removal from the database.
+   *
+   * @param pageable
+   *          paging/limit information (used to bound batch size)
+   * @return a batch of flushed jobs
+   */
+  List<Job> findByFlushedAtIsNotNull(Pageable pageable);
 }

--- a/roda-core/roda-core/src/main/java/org/roda/core/repository/job/ReportRepository.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/repository/job/ReportRepository.java
@@ -40,4 +40,15 @@ public interface ReportRepository extends JpaRepository<Report, String> {
    */
   @Transactional
   void deleteByJobId(String jobId);
+
+  /**
+   * Delete all reports associated with any of the given job IDs, in a single
+   * bulk statement. Used by the flush cleanup task to remove reports for many
+   * already-flushed jobs at once, instead of one DELETE per job.
+   *
+   * @param jobIds
+   *          the job IDs whose reports should be deleted
+   */
+  @Transactional
+  void deleteByJobIdIn(List<String> jobIds);
 }

--- a/roda-ui/roda-wui/src/main/resources/application.properties
+++ b/roda-ui/roda-wui/src/main/resources/application.properties
@@ -36,6 +36,17 @@ spring.sql.init.mode=never
 
 transactions.cleanup.interval.millis=3600000
 
+# Batch cleanup of jobs/reports already flushed to file storage (see
+# DefaultModelService#flushJobToStorage and JobFlushCleanupTask)
+jobs.flush-cleanup.interval.millis=60000
+jobs.flush-cleanup.batch-size=500
+
+# Connection pool sizing: default (10) is too small for bursts of many jobs
+# finishing concurrently (e.g. batch ingest of many SIPs), each needing a
+# connection to flush/mark-flushed while ingest itself is also hitting the DB
+spring.datasource.hikari.maximum-pool-size=30
+spring.datasource.hikari.minimum-idle=10
+
 # Metrics and monitoring
 spring.datasource.hikari.metrics-tracking: true
 management.endpoints.web.exposure.include=health,info,metrics,prometheus

--- a/roda-ui/roda-wui/src/main/resources/db/migration/V3__add_job_flushed_at.sql
+++ b/roda-ui/roda-wui/src/main/resources/db/migration/V3__add_job_flushed_at.sql
@@ -1,0 +1,12 @@
+--
+-- Name: jobs flushed_at; Type: COLUMN; Schema: public; Owner: admin
+--
+-- Marks the moment a completed job's reports were durably written to file
+-- storage. The row itself (and its job_reports rows) is only removed later,
+-- in a batch, by the asynchronous cleanup task -- decoupling the (must
+-- happen immediately) storage flush from the (can be deferred) DB cleanup.
+--
+
+ALTER TABLE public.jobs ADD COLUMN flushed_at timestamp(6) without time zone;
+
+CREATE INDEX idx_jobs_flushed_at ON public.jobs USING btree (flushed_at) WHERE flushed_at IS NOT NULL;


### PR DESCRIPTION
Flushing a completed job to storage previously also deleted its DB rows inline (findByJobId + deleteByJobId + existsById + deleteById per job). Under bursts of many jobs finishing concurrently (e.g. batch SIP ingest), this meant thousands of small, independently-committed transactions competing with live ingest traffic for DB connections and locks.

The storage flush still happens immediately, but jobs are now only marked with a flushedAt timestamp; a new scheduled JobFlushCleanupTask removes flushed jobs and their reports in batches, decoupled from the ingest hot path. Also parallelizes per-job report storage writes and sizes the Hikari pool explicitly instead of relying on the default of 10.