### PR TITLE
Fix file fulltext being wiped by partial Solr updates

### DIFF
--- a/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/FileCollection.java
+++ b/roda-core/roda-core/src/main/java/org/roda/core/index/schema/collections/FileCollection.java
@@ -101,7 +101,7 @@ public class FileCollection extends AbstractSolrCollection<IndexedFile, File> {
     fields.add(new Field(RodaConstants.FILE_REFERENCE_URL, Field.TYPE_STRING));
     fields.add(new Field(RodaConstants.FILE_REFERENCE_MANIFEST, Field.TYPE_STRING));
     fields.add(new Field(RodaConstants.FILE_EXTENSION, Field.TYPE_STRING));
-    fields.add(new Field(RodaConstants.FILE_FULLTEXT, Field.TYPE_TEXT).setMultiValued(false).setStored(false));
+    fields.add(new Field(RodaConstants.FILE_FULLTEXT, Field.TYPE_TEXT).setMultiValued(false));
     fields.add(new Field(RodaConstants.FILE_CREATING_APPLICATION_NAME, Field.TYPE_STRING));
     fields.add(new Field(RodaConstants.FILE_CREATING_APPLICATION_VERSION, Field.TYPE_STRING));
     fields.add(new Field(RodaConstants.FILE_DATE_CREATED_BY_APPLICATION, Field.TYPE_STRING));


### PR DESCRIPTION
## Summary

- `FileCollection`'s `fulltext` field was `stored=false`. Solr's atomic/partial update (`{"set": ...}`) reconstructs the whole document from its stored/docValues fields before re-submitting it, so any field that's neither stored nor docValues is silently dropped in that reconstruction - `fulltext` was being wiped on any partial update to an `IndexedFile` document (e.g. AIP move, which patches `FILE_ANCESTORS`, or AIP permission propagation), taking the `fulltext`→`search` copyField's terms down with it, so basic/default search on the file was affected too, not just explicit `fulltext:` queries.
- Fix: drop `.setStored(false)` so the field uses `Field`'s documented implicit default (`stored=true`), letting Solr correctly preserve it across partial updates. Also makes `fulltext`'s raw value retrievable via `fl=`, which previously silently returned nothing for this field.

Fixes #3733

## Test plan

- [x] Compiles (single-field schema definition change, no other code paths touched)
- [ ] Against a throwaway Solr instance bootstrapped from scratch: confirm the `file` collection reports `stored=true` for `fulltext`, and that `fl=fulltext` returns real content after indexing a file with known text
- [ ] Confirm `fulltext:<term>` and default/basic search both still match a file after triggering a partial update on it (e.g. moving its parent AIP)

Note for anyone applying this against an already-bootstrapped Solr collection: `SolrBootstrapUtils.bootstrapCollection` only logs a warning for an existing field whose attributes no longer match - it never issues a `replace-field` - so this won't retroactively apply to a live collection without either a schema `replace-field` call or a from-scratch re-bootstrap, followed by a full File reindex to repopulate `fulltext` for already-indexed documents.